### PR TITLE
fix: 修复背景遮罩透明度默认值不生效的问题

### DIFF
--- a/FufuLauncher/MainWindow.xaml.cs
+++ b/FufuLauncher/MainWindow.xaml.cs
@@ -1601,11 +1601,11 @@ private Task ApplyGlobalBackgroundAsync(BackgroundRenderResult? result)
         try
         {
             var valueObj = await _localSettingsService.ReadSettingAsync("GlobalBackgroundOverlayOpacity");
-            var opacity = 0.3;
+            var opacity = 0.0;
             if (valueObj != null && double.TryParse(valueObj.ToString(), out var parsed)) opacity = parsed;
             ApplyOverlayOpacity(opacity);
         }
-        catch { ApplyOverlayOpacity(0.3); }
+        catch { ApplyOverlayOpacity(0.0); }
     }
 
     private async Task LoadFrameBackgroundOpacityAsync()

--- a/FufuLauncher/ViewModels/SettingsViewModel.cs
+++ b/FufuLauncher/ViewModels/SettingsViewModel.cs
@@ -503,11 +503,11 @@ namespace FufuLauncher.ViewModels
             var overlayOpacityJson = await _localSettingsService.ReadSettingAsync("GlobalBackgroundOverlayOpacity");
             try
             {
-                GlobalBackgroundOverlayOpacity = overlayOpacityJson != null ? Convert.ToDouble(overlayOpacityJson) : 0.3;
+                GlobalBackgroundOverlayOpacity = overlayOpacityJson != null ? Convert.ToDouble(overlayOpacityJson) : 0;
             }
             catch
             {
-                GlobalBackgroundOverlayOpacity = 0.3;
+                GlobalBackgroundOverlayOpacity = 0;
             }
 
             var frameOpacityJson = await _localSettingsService.ReadSettingAsync("ContentFrameBackgroundOpacity");


### PR DESCRIPTION
将背景遮罩透明度默认值从 0.3 改为 0，并修复 MainWindow 初始化时硬编码 0.3 导致设置页面显示值与实际渲染不一致的问题。

修改内容：

- SettingsViewModel.cs: 默认值从 0.3 改为 0

- MainWindow.xaml.cs: LoadOverlayOpacityAsync() 中的 fallback 值从 0.3 改为 0