### PR TITLE
perf: 优化背景切换性能 - 添加图片缓存与预加载机制

### DIFF
--- a/FufuLauncher/MainWindow.xaml.cs
+++ b/FufuLauncher/MainWindow.xaml.cs
@@ -752,13 +752,13 @@ private Task ApplyGlobalBackgroundAsync(BackgroundRenderResult? result)
             GlobalBackgroundImage.Source = result.ImageSource;
             GlobalBackgroundImage.Visibility = Visibility.Visible;
             
-            await Task.Delay(900); 
+            await Task.Delay(100); 
             
             var fadeInAnimation = new DoubleAnimation
             {
                 From = 0.0,
                 To = finalOpacity,
-                Duration = TimeSpan.FromMilliseconds(1000),
+                Duration = TimeSpan.FromMilliseconds(400),
                 EasingFunction = new CircleEase { EasingMode = EasingMode.EaseOut }
             };
 

--- a/FufuLauncher/Services/Background/BackgroundRenderer.cs
+++ b/FufuLauncher/Services/Background/BackgroundRenderer.cs
@@ -38,6 +38,7 @@ namespace FufuLauncher.Services.Background
         Task<BackgroundRenderResult> GetBackgroundAsync(ServerType server, bool preferVideo);
         Task<BackgroundRenderResult> GetCustomBackgroundAsync(string filePath);
         Task<BackgroundRenderResult> GetSpecificOnlineBackgroundAsync(string url, bool isVideo);
+        Task PreloadImageBackgroundsAsync(IEnumerable<string> imageUrls);
         void ClearBackground();
         void ClearCustomBackground();
     }
@@ -46,9 +47,11 @@ namespace FufuLauncher.Services.Background
     {
         private static readonly HttpClient _httpClient;
 
-        
+        private readonly SemaphoreSlim _loadLock = new(1, 1);
+
         public async Task<BackgroundRenderResult> GetSpecificOnlineBackgroundAsync(string url, bool isVideo)
         {
+            await _loadLock.WaitAsync();
             try
             {
                 if (isVideo)
@@ -66,6 +69,10 @@ namespace FufuLauncher.Services.Background
             {
                 Debug.WriteLine($"指定背景加载失败: {ex.Message}");
                 return GetFallbackBackground();
+            }
+            finally
+            {
+                _loadLock.Release();
             }
         }
         
@@ -112,6 +119,7 @@ namespace FufuLauncher.Services.Background
 
         public async Task<BackgroundRenderResult> GetBackgroundAsync(ServerType server, bool preferVideo)
         {
+            await _loadLock.WaitAsync();
             try
             {
                 var backgroundService = App.GetService<IHoyoverseBackgroundService>();
@@ -127,7 +135,7 @@ namespace FufuLauncher.Services.Background
 
                 if (backgroundInfo.Url == _currentBackgroundUrl && _cachedBackground != null)
                 {
-                    Debug.WriteLine("BackgroundRenderer: 使用缓存媒体");
+                    Debug.WriteLine("BackgroundRenderer: 使用内存缓存媒体");
                     return _cachedBackground;
                 }
 
@@ -159,6 +167,10 @@ namespace FufuLauncher.Services.Background
             {
                 Debug.WriteLine($"BackgroundRenderer: 加载或处理背景失败 - {ex.Message}");
                 return GetFallbackBackground();
+            }
+            finally
+            {
+                _loadLock.Release();
             }
         }
 
@@ -250,16 +262,59 @@ namespace FufuLauncher.Services.Background
 
         private async Task<ImageSource> ProcessImageBackground(string imageUrl)
         {
+            var fileName = GetCacheFileName(imageUrl, ".img");
+            var cachedFilePath = Path.Combine(_cacheFolderPath, fileName);
+
+            // 优先从文件缓存加载
+            if (File.Exists(cachedFilePath))
+            {
+                var fileInfo = new FileInfo(cachedFilePath);
+                if (fileInfo.Length > 1024)
+                {
+                    try
+                    {
+                        Debug.WriteLine($"BackgroundRenderer: 从文件缓存加载图片: {fileName}");
+                        var bitmap = new BitmapImage();
+                        using (var stream = File.OpenRead(cachedFilePath))
+                        {
+                            await bitmap.SetSourceAsync(stream.AsRandomAccessStream());
+                        }
+                        return bitmap;
+                    }
+                    catch
+                    {
+                        File.Delete(cachedFilePath);
+                        Debug.WriteLine($"BackgroundRenderer: 图片缓存损坏，已删除 {fileName}");
+                    }
+                }
+            }
+
+            // 缓存不存在，从网络下载
             Debug.WriteLine($"BackgroundRenderer: 开始下载图片: {imageUrl}");
             var data = await _httpClient.GetByteArrayAsync(imageUrl);
             Debug.WriteLine($"BackgroundRenderer: 下载完成，大小 {data.Length} bytes");
 
-            var bitmap = new BitmapImage();
+            // 保存到文件缓存
+            try
+            {
+                Directory.CreateDirectory(_cacheFolderPath);
+                var tempFile = Path.Combine(_cacheFolderPath, $"{fileName}.tmp");
+                await File.WriteAllBytesAsync(tempFile, data);
+                File.Move(tempFile, cachedFilePath, true);
+                Debug.WriteLine($"BackgroundRenderer: 图片已缓存到 {fileName}");
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"BackgroundRenderer: 图片缓存写入失败: {ex.Message}");
+            }
+
+            // 从下载数据解码
+            var bitmapImage = new BitmapImage();
             using (var stream = new MemoryStream(data))
             {
                 try
                 {
-                    await bitmap.SetSourceAsync(stream.AsRandomAccessStream());
+                    await bitmapImage.SetSourceAsync(stream.AsRandomAccessStream());
                 }
                 catch (Exception ex)
                 {
@@ -269,12 +324,12 @@ namespace FufuLauncher.Services.Background
             }
 
             Debug.WriteLine("BackgroundRenderer: BitmapImage 从流加载完成");
-            return bitmap;
+            return bitmapImage;
         }
 
-        private string GetCacheFileName(string url)
+        private string GetCacheFileName(string url, string defaultExtension = ".mp4")
         {
-            var extension = ".mp4";
+            var extension = defaultExtension;
             try
             {
                 var uri = new Uri(url);
@@ -316,6 +371,38 @@ namespace FufuLauncher.Services.Background
 
             _cachedBackground = null;
             _currentBackgroundUrl = null;
+        }
+
+        public async Task PreloadImageBackgroundsAsync(IEnumerable<string> imageUrls)
+        {
+            var tasks = imageUrls.Select(async url =>
+            {
+                try
+                {
+                    var fileName = GetCacheFileName(url, ".img");
+                    var cachedFilePath = Path.Combine(_cacheFolderPath, fileName);
+
+                    if (File.Exists(cachedFilePath) && new FileInfo(cachedFilePath).Length > 1024)
+                    {
+                        Debug.WriteLine($"BackgroundRenderer: 预加载跳过(已缓存): {fileName}");
+                        return;
+                    }
+
+                    Debug.WriteLine($"BackgroundRenderer: 预加载下载中: {url}");
+                    var data = await _httpClient.GetByteArrayAsync(url);
+                    Directory.CreateDirectory(_cacheFolderPath);
+                    var tempFile = Path.Combine(_cacheFolderPath, $"{fileName}.tmp");
+                    await File.WriteAllBytesAsync(tempFile, data);
+                    File.Move(tempFile, cachedFilePath, true);
+                    Debug.WriteLine($"BackgroundRenderer: 预加载完成: {fileName}");
+                }
+                catch (Exception ex)
+                {
+                    Debug.WriteLine($"BackgroundRenderer: 预加载失败({url}): {ex.Message}");
+                }
+            });
+
+            await Task.WhenAll(tasks);
         }
 
         public void ClearCustomBackground()

--- a/FufuLauncher/ViewModels/MainViewModel.cs
+++ b/FufuLauncher/ViewModels/MainViewModel.cs
@@ -239,6 +239,12 @@ namespace FufuLauncher.ViewModels
                         AvailableBackgrounds.Add(bg);
                     }
                 });
+
+                // 后台预加载所有图片背景到文件缓存
+                var imageUrls = backgrounds
+                    .Where(b => !b.IsVideo && !string.IsNullOrEmpty(b.Url))
+                    .Select(b => b.Url);
+                _ = _backgroundRenderer.PreloadImageBackgroundsAsync(imageUrls);
             }
             catch (Exception ex)
             {

--- a/FufuLauncher/Views/Main/MainPage.xaml.cs
+++ b/FufuLauncher/Views/Main/MainPage.xaml.cs
@@ -19,8 +19,6 @@ public sealed partial class MainPage : Page
 {
     private const double BannerSwipeThreshold = 42;
     private const double BannerAnimationMs = 460;
-    private DateTimeOffset _lastBackgroundSwitchTime = DateTimeOffset.MinValue;
-    private static readonly TimeSpan BackgroundSwitchCooldown = TimeSpan.FromSeconds(2);
     private BannerItem _displayedBanner;
     private bool _isBannerTransitioning;
     private bool _isBannerPointerPressed;
@@ -341,17 +339,8 @@ private async void ChangeUidButton_Click(object sender, RoutedEventArgs e)
     
     private void BackgroundGridView_ItemClick(object sender, ItemClickEventArgs e)
     {
-        var now = DateTimeOffset.Now;
-        if (now - _lastBackgroundSwitchTime < BackgroundSwitchCooldown)
-        {
-            var notificationService = App.GetService<INotificationService>();
-            notificationService.Show("背景切换过快", "还在切换中，请等待2秒", NotificationType.Warning, 2000);
-            return;
-        }
-
         if (e.ClickedItem is BackgroundUrlInfo info)
         {
-            _lastBackgroundSwitchTime = now;
             ViewModel.SelectSpecificBackgroundCommand.Execute(info);
             
             BackgroundFlyout.Hide();


### PR DESCRIPTION
改动内容：

1. 图片背景文件缓存：图片背景现在和视频一样会缓存到本地文件，再次切换同一张图时直接从磁盘读取，跳过网络请求

2. 后台预加载：加载可用背景列表后，后台并行预下载所有图片到本地缓存，用户切换时几乎瞬间完成

3. 移除切换冷却限制：移除原有的 2 秒切换间隔限制，配合缓存机制确保快速切换不卡顿

4. 切换动画提速：等待延迟从 900ms 降至 100ms，淡入动画从 1000ms 降至 400ms

5. 并发控制：添加 SemaphoreSlim 确保同时只有一个背景加载任务执行，防止快速切换产生竞态