### PR TITLE
Feat:修改国际服签到系统，新增API支持

### DIFF
--- a/FufuLauncher/Models/HoyolabCheckinService.cs
+++ b/FufuLauncher/Models/HoyolabCheckinService.cs
@@ -1,0 +1,432 @@
+using System.Net;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace FufuLauncher.Models
+{
+    // OS 签到奖励
+    public class OsRewardItem
+    {
+        [JsonPropertyName("name")] public string Name { get; set; }
+        [JsonPropertyName("cnt")] public int Count { get; set; }
+    }
+
+    // OS 签到奖励列表
+    public class OsCheckinRewardsData
+    {
+        [JsonPropertyName("awards")] public List<OsRewardItem> Awards { get; set; }
+    }
+
+    // OS 账号信息
+    public class OsAccountItem
+    {
+        [JsonPropertyName("nickname")] public string Nickname { get; set; }
+        [JsonPropertyName("game_uid")] public string GameUid { get; set; }
+        [JsonPropertyName("region")] public string Region { get; set; }
+    }
+
+    public class OsAccountInfoData
+    {
+        [JsonPropertyName("list")] public List<OsAccountItem> List { get; set; }
+    }
+
+    // OS 签到状态
+    public class OsIsSignData
+    {
+        [JsonPropertyName("total_sign_day")] public int TotalSignDay { get; set; }
+        [JsonPropertyName("today")] public string Today { get; set; }
+        [JsonPropertyName("is_sign")] public bool IsSign { get; set; }
+        [JsonPropertyName("first_bind")] public bool FirstBind { get; set; }
+    }
+
+    // OS 通用 API 响应包装
+    public class OsApiResponse<T>
+    {
+        [JsonPropertyName("retcode")] public int RetCode { get; set; }
+        [JsonPropertyName("message")] public string Message { get; set; }
+        [JsonPropertyName("data")] public T Data { get; set; }
+    }
+
+    // OS 签到响应
+    public class OsSignResponseData
+    {
+        [JsonPropertyName("success")] public int Success { get; set; }
+        [JsonPropertyName("gt")] public string Gt { get; set; }
+        [JsonPropertyName("challenge")] public string Challenge { get; set; }
+    }
+
+    public class HoyolabCheckinService
+    {
+        // 可配置项
+        public string BaseApi { get; set; } = "https://sg-hk4e-api.hoyolab.com";
+        public string ActId { get; set; } = "e202102251931481";
+        public string GameBiz { get; set; } = "hk4e_global";
+        public string DsSalt { get; set; } = "okr4obncj8bw5a65hbnn5oo6ixjc3l9w";
+        public string DsSalt2 { get; set; } = "h4c1d6ywfq5bsbnbhm1bzq7bxzzv6srt";
+
+        private HttpClient _httpClient;
+        private Dictionary<string, string> _headers;
+
+        public static string LastApiError { get; set; } = string.Empty;
+        public static int LastSignDays { get; set; } = 0;
+        public static string LastRewardItem { get; set; } = "无/未知";
+
+        public List<OsAccountItem> AccountList { get; private set; } = new();
+        private List<OsRewardItem> _checkinRewards;
+
+        public HoyolabCheckinService()
+        {
+            _httpClient = new HttpClient(new HttpClientHandler
+            {
+                AutomaticDecompression = DecompressionMethods.GZip | DecompressionMethods.Deflate
+            });
+            _httpClient.Timeout = TimeSpan.FromSeconds(30);
+        }
+
+        // 构建请求头
+        private void SetHeaders(string cookie)
+        {
+            var deviceId = Guid.NewGuid().ToString("N");
+
+            _headers = new Dictionary<string, string>
+            {
+                ["Accept"] = "application/json, text/plain, */*",
+                ["Origin"] = "https://act.hoyolab.com",
+                ["x-rpc-app_version"] = "3.13.0",
+                ["x-rpc-client_type"] = "5",
+                ["x-rpc-language"] = "zh-cn",
+                ["Referer"] = "https://act.hoyolab.com/",
+                ["Accept-Encoding"] = "gzip, deflate",
+                ["Accept-Language"] = "zh-CN,en-US;q=0.8",
+                ["Cookie"] = cookie,
+                ["x-rpc-device_id"] = deviceId,
+                ["x-rpc-game_biz"] = GameBiz,
+                ["X-Requested-With"] = "com.mihoyo.hoyolab",
+                ["User-Agent"] = "Mozilla/5.0 (Linux; Android 13; Pixel 5) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/118.0.0.0 Mobile Safari/537.36 miHoYoBBSOversea/3.13.0"
+            };
+        }
+
+        private string GenerateDs()
+        {
+            var t = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
+            var r = RandomString(6);
+            var c = Md5($"salt={DsSalt}&t={t}&r={r}");
+            return $"{t},{r},{c}";
+        }
+
+        private string GenerateDs2(string body = "", string query = "")
+        {
+            var t = DateTimeOffset.UtcNow.ToUnixTimeSeconds().ToString();
+            var r = new Random().Next(100001, 200000).ToString();
+            var b = string.IsNullOrEmpty(body) ? "" : body;
+            var q = string.IsNullOrEmpty(query) ? "" : query;
+
+            if (!string.IsNullOrEmpty(q))
+            {
+                var pairs = q.Split('&').OrderBy(x => x).ToArray();
+                q = string.Join("&", pairs);
+            }
+
+            var c = Md5($"salt={DsSalt2}&t={t}&r={r}&b={b}&q={q}");
+            return $"{t},{r},{c}";
+        }
+
+        private string Md5(string input)
+        {
+            using (var md5 = MD5.Create())
+            {
+                var bytes = Encoding.UTF8.GetBytes(input);
+                var hash = md5.ComputeHash(bytes);
+                return BitConverter.ToString(hash).Replace("-", "").ToLower();
+            }
+        }
+
+        private string RandomString(int length)
+        {
+            const string chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+            var r = new Random();
+            return new string(Enumerable.Range(0, length).Select(_ => chars[r.Next(chars.Length)]).ToArray());
+        }
+
+        private void AddHeaders(HttpRequestMessage request)
+        {
+            foreach (var h in _headers)
+                AddHeader(request, h.Key, h.Value);
+        }
+
+        private void AddHeader(HttpRequestMessage request, string key, string value)
+        {
+            if (string.IsNullOrEmpty(value)) return;
+            switch (key.ToLower())
+            {
+                case "cookie":
+                    request.Headers.Add("Cookie", value);
+                    break;
+                case "user-agent":
+                    request.Headers.UserAgent.ParseAdd(value);
+                    break;
+                case "referer":
+                    request.Headers.Referrer = new Uri(value);
+                    break;
+                case "accept-encoding":
+                case "accept-language":
+                    request.Headers.TryAddWithoutValidation(key, value);
+                    break;
+                default:
+                    request.Headers.Add(key, value);
+                    break;
+            }
+        }
+
+        // 初始化：获取账号列表 + 奖励列表
+        public async Task InitializeAsync(string cookie)
+        {
+            LastApiError = string.Empty;
+            SetHeaders(cookie);
+            AccountList = await GetAccountListAsync();
+            if (AccountList.Count > 0)
+                _checkinRewards = await GetCheckinRewardsAsync();
+        }
+
+        private async Task<List<OsAccountItem>> GetAccountListAsync()
+        {
+            try
+            {
+                var query = $"game_biz={GameBiz}";
+                var url = $"https://api-account-os.hoyolab.com/binding/api/getUserGameRolesByCookieToken?{query}";
+                using var req = new HttpRequestMessage(HttpMethod.Get, url);
+                AddHeaders(req);
+                req.Headers.Remove("DS");
+                req.Headers.Add("DS", GenerateDs2(query: query));
+                var resp = await _httpClient.SendAsync(req);
+                var text = await resp.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<OsApiResponse<OsAccountInfoData>>(text);
+                if (result != null && result.RetCode == 0 && result.Data?.List != null)
+                    return result.Data.List;
+                LastApiError = result?.Message ?? "解析账号列表失败";
+            }
+            catch (Exception ex)
+            {
+                LastApiError = $"获取账号列表异常: {ex.Message}";
+            }
+            return new List<OsAccountItem>();
+        }
+
+        private async Task<List<OsRewardItem>> GetCheckinRewardsAsync()
+        {
+            for (int i = 0; i < 3; i++)
+            {
+                try
+                {
+                    var query = $"act_id={ActId}&lang=zh-cn";
+                    var url = $"{BaseApi}/event/sol/home?{query}";
+                    using var req = new HttpRequestMessage(HttpMethod.Get, url);
+                    AddHeaders(req);
+                    req.Headers.Remove("DS");
+                    req.Headers.Add("DS", GenerateDs2(query: query));
+                    var resp = await _httpClient.SendAsync(req);
+                    var text = await resp.Content.ReadAsStringAsync();
+                    var result = JsonSerializer.Deserialize<OsApiResponse<OsCheckinRewardsData>>(text);
+                    if (result != null && result.RetCode == 0 && result.Data?.Awards != null)
+                        return result.Data.Awards;
+                }
+                catch { }
+                await Task.Delay(5000);
+            }
+            return new List<OsRewardItem>();
+        }
+
+        public async Task<OsIsSignData> IsSignAsync(string region, string uid)
+        {
+            try
+            {
+                var query = $"act_id={ActId}&lang=zh-cn&region={region}&uid={uid}";
+                var url = $"{BaseApi}/event/sol/info?{query}";
+                using var req = new HttpRequestMessage(HttpMethod.Get, url);
+                AddHeaders(req);
+                req.Headers.Remove("DS");
+                req.Headers.Add("DS", GenerateDs2(query: query));
+                var resp = await _httpClient.SendAsync(req);
+                var text = await resp.Content.ReadAsStringAsync();
+                var result = JsonSerializer.Deserialize<OsApiResponse<OsIsSignData>>(text);
+                if (result != null && result.RetCode == 0 && result.Data != null)
+                    return result.Data;
+                LastApiError = result?.Message ?? "解析签到状态失败";
+            }
+            catch (Exception ex)
+            {
+                LastApiError = $"请求签到状态异常: {ex.Message}";
+            }
+            return null;
+        }
+
+        // 执行签到请求
+        private async Task<HttpResponseMessage> DoSignAsync(OsAccountItem account)
+        {
+            var headers = new Dictionary<string, string>(_headers);
+
+            for (int i = 1; i <= 4; i++)
+            {
+                try
+                {
+                    var body = new { act_id = ActId, region = account.Region, uid = account.GameUid };
+                    var jsonBody = JsonSerializer.Serialize(body);
+
+                    using var req = new HttpRequestMessage(HttpMethod.Post, $"{BaseApi}/event/sol/sign");
+                    foreach (var h in headers)
+                        AddHeader(req, h.Key, h.Value);
+
+                    req.Content = new StringContent(jsonBody, Encoding.UTF8, "application/json");
+
+                    // 覆盖 DS（POST 需要带 body 的 DS）
+                    req.Headers.Remove("DS");
+                    req.Headers.Add("DS", GenerateDs2(body: jsonBody));
+
+                    var resp = await _httpClient.SendAsync(req);
+                    if ((int)resp.StatusCode == 429)
+                    {
+                        await Task.Delay(10000);
+                        continue;
+                    }
+                    return resp;
+                }
+                catch { return null; }
+            }
+            return null;
+        }
+
+        // 主签到逻辑
+        public async Task<string> SignAccountAsync(string cookie, HashSet<string> disabledUids = null)
+        {
+            LastApiError = string.Empty;
+            var result = "HoYoLAB: ";
+
+            if (AccountList.Count == 0)
+            {
+                result += "未检测到绑定账号";
+                if (!string.IsNullOrEmpty(LastApiError))
+                    result += $"，原因: {LastApiError}";
+                return result;
+            }
+
+            foreach (var account in AccountList)
+            {
+                if (disabledUids != null && disabledUids.Contains(account.GameUid))
+                    continue;
+
+                await Task.Delay(new Random().Next(2000, 8000));
+
+                var isData = await IsSignAsync(account.Region, account.GameUid);
+                if (isData == null)
+                {
+                    result += $"\n{account.Nickname} 获取签到信息失败";
+                    if (!string.IsNullOrEmpty(LastApiError))
+                        result += $"，详情: {LastApiError}";
+                    continue;
+                }
+
+                if (isData.FirstBind)
+                {
+                    result += $"\n{account.Nickname}是第一次绑定HoYoLAB，请先手动签到一次";
+                    continue;
+                }
+
+                var signDays = isData.TotalSignDay - 1;
+
+                if (isData.IsSign)
+                {
+                    if (_checkinRewards != null && _checkinRewards.Count > signDays)
+                    {
+                        result += $"\n{account.Nickname}今天已经签到过了";
+                        result += $"\n今天获得的奖励是{FormatItem(_checkinRewards[signDays])}";
+                        signDays += 1;
+                    }
+                    else
+                    {
+                        result += $"\n{account.Nickname}今天已经签到过了";
+                        signDays += 1;
+                    }
+                }
+                else
+                {
+                    await Task.Delay(new Random().Next(2000, 8000));
+
+                    var req = await DoSignAsync(account);
+                    if (req == null)
+                    {
+                        result += $"\n{account.Nickname} 本次签到请求失败";
+                        if (!string.IsNullOrEmpty(LastApiError))
+                            result += $"，详情: {LastApiError}";
+                        continue;
+                    }
+
+                    if ((int)req.StatusCode != 429)
+                    {
+                        var text = await req.Content.ReadAsStringAsync();
+                        var data = JsonSerializer.Deserialize<OsApiResponse<OsSignResponseData>>(text);
+
+                        if (data != null)
+                        {
+                            if (data.RetCode == 0 && data.Data != null && data.Data.Success == 0)
+                            {
+                                var idx = signDays == 0 ? 0 : signDays + 1;
+                                if (_checkinRewards != null && _checkinRewards.Count > idx)
+                                {
+                                    result += $"\n{account.Nickname}签到成功";
+                                    result += $"\n奖励是{FormatItem(_checkinRewards[idx])}";
+                                    signDays += 2;
+                                }
+                                else
+                                {
+                                    result += $"\n{account.Nickname}签到成功";
+                                    signDays += 2;
+                                }
+                            }
+                            else if (data.RetCode == -5003)
+                            {
+                                if (_checkinRewards != null && _checkinRewards.Count > signDays)
+                                {
+                                    result += $"\n{account.Nickname}今天已经签到过了";
+                                    result += $"\n奖励是{FormatItem(_checkinRewards[signDays])}";
+                                }
+                            }
+                            else
+                            {
+                                result += $"\n{account.Nickname} 签到失败，API提示: {data.Message}";
+                                continue;
+                            }
+                        }
+                        else
+                        {
+                            result += $"\n{account.Nickname} 解析签到结果失败";
+                            continue;
+                        }
+                    }
+                    else
+                    {
+                        result += $"\n{account.Nickname} 签到失败，触发 HTTP 429 限流";
+                        continue;
+                    }
+                }
+
+                result += $"\n{account.Nickname}已签到{signDays}天";
+                LastSignDays = signDays;
+
+                if (_checkinRewards != null && _checkinRewards.Count > signDays - 1)
+                {
+                    LastRewardItem = FormatItem(_checkinRewards[signDays - 1]);
+                    result += $"\n奖励是{LastRewardItem}";
+                }
+            }
+
+            return result;
+        }
+
+        private string FormatItem(OsRewardItem item)
+        {
+            return $"「{item.Name}」x{item.Count}";
+        }
+    }
+}

--- a/FufuLauncher/Models/HoyolabCheckinService.cs
+++ b/FufuLauncher/Models/HoyolabCheckinService.cs
@@ -52,9 +52,8 @@ namespace FufuLauncher.Models
     // OS 签到响应
     public class OsSignResponseData
     {
-        [JsonPropertyName("success")] public int Success { get; set; }
-        [JsonPropertyName("gt")] public string Gt { get; set; }
-        [JsonPropertyName("challenge")] public string Challenge { get; set; }
+        [JsonPropertyName("code")] public string Code { get; set; }
+        [JsonPropertyName("first_bind")] public bool FirstBind { get; set; }
     }
 
     public class HoyolabCheckinService
@@ -333,21 +332,14 @@ namespace FufuLauncher.Models
                     continue;
                 }
 
-                var signDays = isData.TotalSignDay - 1;
+                var signDays = isData.TotalSignDay;
 
                 if (isData.IsSign)
                 {
-                    if (_checkinRewards != null && _checkinRewards.Count > signDays)
-                    {
-                        result += $"\n{account.Nickname}今天已经签到过了";
-                        result += $"\n今天获得的奖励是{FormatItem(_checkinRewards[signDays])}";
-                        signDays += 1;
-                    }
-                    else
-                    {
-                        result += $"\n{account.Nickname}今天已经签到过了";
-                        signDays += 1;
-                    }
+                    result += $"\n{account.Nickname}今天已经签到过了";
+                    var idx = signDays - 1;
+                    if (_checkinRewards != null && idx >= 0 && idx < _checkinRewards.Count)
+                        result += $"\n今天获得的奖励是{FormatItem(_checkinRewards[idx])}";
                 }
                 else
                 {
@@ -362,51 +354,33 @@ namespace FufuLauncher.Models
                         continue;
                     }
 
-                    if ((int)req.StatusCode != 429)
+                    if ((int)req.StatusCode == 429)
                     {
-                        var text = await req.Content.ReadAsStringAsync();
-                        var data = JsonSerializer.Deserialize<OsApiResponse<OsSignResponseData>>(text);
+                        result += $"\n{account.Nickname} 签到失败，触发 HTTP 429 限流";
+                        continue;
+                    }
 
-                        if (data != null)
-                        {
-                            if (data.RetCode == 0 && data.Data != null && data.Data.Success == 0)
-                            {
-                                var idx = signDays == 0 ? 0 : signDays + 1;
-                                if (_checkinRewards != null && _checkinRewards.Count > idx)
-                                {
-                                    result += $"\n{account.Nickname}签到成功";
-                                    result += $"\n奖励是{FormatItem(_checkinRewards[idx])}";
-                                    signDays += 2;
-                                }
-                                else
-                                {
-                                    result += $"\n{account.Nickname}签到成功";
-                                    signDays += 2;
-                                }
-                            }
-                            else if (data.RetCode == -5003)
-                            {
-                                if (_checkinRewards != null && _checkinRewards.Count > signDays)
-                                {
-                                    result += $"\n{account.Nickname}今天已经签到过了";
-                                    result += $"\n奖励是{FormatItem(_checkinRewards[signDays])}";
-                                }
-                            }
-                            else
-                            {
-                                result += $"\n{account.Nickname} 签到失败，API提示: {data.Message}";
-                                continue;
-                            }
-                        }
-                        else
-                        {
-                            result += $"\n{account.Nickname} 解析签到结果失败";
-                            continue;
-                        }
+                    var text = await req.Content.ReadAsStringAsync();
+                    var data = JsonSerializer.Deserialize<OsApiResponse<OsSignResponseData>>(text);
+
+                    if (data == null)
+                    {
+                        result += $"\n{account.Nickname} 解析签到结果失败";
+                        continue;
+                    }
+
+                    if (data.RetCode == 0 && data.Data?.Code == "ok")
+                    {
+                        signDays++;
+                        result += $"\n{account.Nickname}签到成功";
+                    }
+                    else if (data.RetCode == -5003)
+                    {
+                        result += $"\n{account.Nickname}今天已经签到过了";
                     }
                     else
                     {
-                        result += $"\n{account.Nickname} 签到失败，触发 HTTP 429 限流";
+                        result += $"\n{account.Nickname} 签到失败，API提示: {data.Message}";
                         continue;
                     }
                 }
@@ -414,9 +388,10 @@ namespace FufuLauncher.Models
                 result += $"\n{account.Nickname}已签到{signDays}天";
                 LastSignDays = signDays;
 
-                if (_checkinRewards != null && _checkinRewards.Count > signDays - 1)
+                var rewardIdx = signDays - 1;
+                if (_checkinRewards != null && rewardIdx >= 0 && rewardIdx < _checkinRewards.Count)
                 {
-                    LastRewardItem = FormatItem(_checkinRewards[signDays - 1]);
+                    LastRewardItem = FormatItem(_checkinRewards[rewardIdx]);
                     result += $"\n奖励是{LastRewardItem}";
                 }
             }

--- a/FufuLauncher/Services/HoyoverseCheckinService.cs
+++ b/FufuLauncher/Services/HoyoverseCheckinService.cs
@@ -1,5 +1,7 @@
-﻿using System.Text.Json;
+﻿using System.Diagnostics;
+using System.Text.Json;
 using FufuLauncher.Contracts.Services;
+using FufuLauncher.Models;
 using MihoyoBBS;
 
 namespace FufuLauncher.Services;
@@ -44,6 +46,36 @@ public class HoyoverseCheckinService : IHoyoverseCheckinService
         return new HashSet<string>();
     }
 
+    private async Task<(string? cookie, string? configPath)> GetOsConfigAsync()
+    {
+        var activeFileObj = await _localSettingsService.ReadSettingAsync("ActiveConfigFile");
+        var activeFile = activeFileObj?.ToString() ?? "config.lab.json";
+        var paths = new[]
+        {
+            Path.Combine(Helpers.AppPaths.DataDir, "config.lab.json"),
+            Path.Combine(AppContext.BaseDirectory, "config.lab.json"),
+            Path.Combine(Environment.CurrentDirectory, "config.lab.json"),
+        };
+        foreach (var path in paths)
+        {
+            if (!File.Exists(path)) continue;
+            try
+            {
+                var json = await File.ReadAllTextAsync(path);
+                var doc = JsonDocument.Parse(json);
+                var cookie = doc.RootElement.GetProperty("Account").GetProperty("Cookie").GetString();
+                if (!string.IsNullOrEmpty(cookie) && IsOsCookie(cookie)) return (cookie, path);
+            }
+            catch { }
+        }
+        return (null, null);
+    }
+
+    private static bool IsOsCookie(string cookie)
+    {
+        return cookie.Contains("ltuid") || cookie.Contains("ltoken") || cookie.Contains("account_id");
+    }
+
     public async Task<List<string>> GetBoundUidsAsync()
     {
         var config = await LoadConfigWithLoggingAsync();
@@ -56,6 +88,36 @@ public class HoyoverseCheckinService : IHoyoverseCheckinService
 
     public async Task<(string status, string summary)> GetCheckinStatusAsync(string targetUid = null)
     {
+        var isIntlRaw = await _localSettingsService.ReadSettingAsync("IsInternationalAccount");
+        bool isOs = isIntlRaw != null && isIntlRaw.ToString().ToLower() == "true";
+        Debug.WriteLine($"[GetCheckinStatus] isOs={isOs}");
+
+        if (isOs)
+        {
+            var (cookie, cfgPath) = await GetOsConfigAsync();
+            Debug.WriteLine($"[GetCheckinStatus] OS cookie found={!string.IsNullOrEmpty(cookie)} path={cfgPath}");
+            if (string.IsNullOrEmpty(cookie))
+                return ("HoYoLAB 未登录", "请先登录国际服账号");
+
+            var os = new HoyolabCheckinService();
+            await os.InitializeAsync(cookie).ConfigureAwait(false);
+            Debug.WriteLine($"[GetCheckinStatus] OS accounts={os.AccountList.Count} lastError={HoyolabCheckinService.LastApiError}");
+
+            if (os.AccountList.Count == 0)
+                return ("未检测到绑定", HoyolabCheckinService.LastApiError);
+
+            var account = os.AccountList[0];
+            var isData = await os.IsSignAsync(account.Region, account.GameUid).ConfigureAwait(false);
+            Debug.WriteLine($"[GetCheckinStatus] IsSign result={isData != null} lastError={HoyolabCheckinService.LastApiError}");
+
+            if (isData == null)
+                return ("获取状态失败", HoyolabCheckinService.LastApiError);
+
+            var signedText = isData.IsSign ? "今日已签到" : "今日未签到";
+            Debug.WriteLine($"[GetCheckinStatus] signed={isData.IsSign}");
+            return (signedText, $"HoYoLAB: {account.Nickname}");
+        }
+
         var config = await LoadConfigWithLoggingAsync();
         if (!config.Games.Cn.Enable || !config.Games.Cn.Genshin.Checkin)
             return ("签到功能未启用", "config.json中设置Enable=true");
@@ -71,11 +133,11 @@ public class HoyoverseCheckinService : IHoyoverseCheckinService
             return ("未检测到账号", errorSummary);
         }
 
-        var account = string.IsNullOrEmpty(targetUid)
+        var cnAccount = string.IsNullOrEmpty(targetUid)
             ? genshin.AccountList[0]
             : genshin.AccountList.FirstOrDefault(a => a.GameUid == targetUid) ?? genshin.AccountList[0];
 
-        var isSignData = await genshin.IsSignAsync(account.Region, account.GameUid, false).ConfigureAwait(false);
+        var isSignData = await genshin.IsSignAsync(cnAccount.Region, cnAccount.GameUid, false).ConfigureAwait(false);
 
         if (isSignData == null)
         {
@@ -86,8 +148,8 @@ public class HoyoverseCheckinService : IHoyoverseCheckinService
         }
 
         return isSignData.IsSign == true
-            ? ("今日已签到", $"账号: {account.Nickname}")
-            : ("今日未签到", $"账号: {account.Nickname} (可签到)");
+            ? ("今日已签到", $"账号: {cnAccount.Nickname}")
+            : ("今日未签到", $"账号: {cnAccount.Nickname} (可签到)");
     }
 
     public async Task<(bool success, string message)> ExecuteCheckinAsync(string targetUid = null)

--- a/FufuLauncher/Services/TokenRefreshService.cs
+++ b/FufuLauncher/Services/TokenRefreshService.cs
@@ -40,6 +40,21 @@ public class TokenRefreshService
         try
         {
             var path = Helpers.AppPaths.ConfigFile;
+
+            // OS 模式只读 config.lab.json，不触发 CN 的 token 刷新
+            if (File.Exists(Helpers.AppPaths.ConfigLabFile))
+            {
+                var labJson = await File.ReadAllTextAsync(Helpers.AppPaths.ConfigLabFile);
+                var labDoc = JsonDocument.Parse(labJson);
+                if (labDoc.RootElement.TryGetProperty("Account", out var labAccount) &&
+                    labAccount.TryGetProperty("Cookie", out var labCookie) &&
+                    !string.IsNullOrEmpty(labCookie.GetString()))
+                {
+                    Debug.WriteLine("[TokenRefresh] 检测到 OS 配置文件，跳过 CN Token 刷新");
+                    return;
+                }
+            }
+
             if (!File.Exists(path))
             {
                 if (isManual) SendErrorNotification("未找到配置文件");

--- a/FufuLauncher/Services/TokenRefreshService.cs
+++ b/FufuLauncher/Services/TokenRefreshService.cs
@@ -41,20 +41,6 @@ public class TokenRefreshService
         {
             var path = Helpers.AppPaths.ConfigFile;
 
-            // OS 模式只读 config.lab.json，不触发 CN 的 token 刷新
-            if (File.Exists(Helpers.AppPaths.ConfigLabFile))
-            {
-                var labJson = await File.ReadAllTextAsync(Helpers.AppPaths.ConfigLabFile);
-                var labDoc = JsonDocument.Parse(labJson);
-                if (labDoc.RootElement.TryGetProperty("Account", out var labAccount) &&
-                    labAccount.TryGetProperty("Cookie", out var labCookie) &&
-                    !string.IsNullOrEmpty(labCookie.GetString()))
-                {
-                    Debug.WriteLine("[TokenRefresh] 检测到 OS 配置文件，跳过 CN Token 刷新");
-                    return;
-                }
-            }
-
             if (!File.Exists(path))
             {
                 if (isManual) SendErrorNotification("未找到配置文件");
@@ -70,6 +56,18 @@ public class TokenRefreshService
                 return;
             }
             
+            var cookieDict = ParseCookieString(config.Account.Cookie);
+            cookieDict.TryGetValue("stoken", out string stoken);
+            cookieDict.TryGetValue("mid", out string mid);
+
+            if (string.IsNullOrEmpty(stoken) || string.IsNullOrEmpty(mid))
+            {
+                Debug.WriteLine("本地Cookie中缺少stoken或mid，无法刷新");
+                if (!isManual) return;
+                SendErrorNotification("本地Cookie中缺少stoken或mid，无法刷新");
+                return;
+            }
+
             if (!isManual)
             {
                 bool isValid = await CheckCookieValidAsync(config.Account.Cookie);
@@ -83,18 +81,6 @@ public class TokenRefreshService
             Debug.WriteLine(isManual ? "用户手动触发Coken刷新..." : "当前Cookie已失效或角色列表为空，开始执行Coken刷新...");
             
             WeakReferenceMessenger.Default.Send(new NotificationMessage("Cookie刷新", isManual ? "正在执行手动刷新..." : "Cookie已失效，正在执行刷新...", NotificationType.Warning, 3000));
-
-            var cookieDict = ParseCookieString(config.Account.Cookie);
-            
-            cookieDict.TryGetValue("stoken", out string stoken);
-            cookieDict.TryGetValue("mid", out string mid);
-
-            if (string.IsNullOrEmpty(stoken) || string.IsNullOrEmpty(mid))
-            {
-                Debug.WriteLine("本地Cookie中缺少stoken或mid，无法刷新");
-                if (isManual) SendErrorNotification("本地Cookie中缺少stoken或mid，无法刷新");
-                return;
-            }
 
             string authCookie = $"stoken={stoken}; mid={mid}";
             

--- a/FufuLauncher/Services/UnifiedCheckinService.cs
+++ b/FufuLauncher/Services/UnifiedCheckinService.cs
@@ -5,6 +5,7 @@ using System.Text.RegularExpressions;
 using FufuLauncher.Contracts.Services;
 using FufuLauncher.Helpers;
 using FufuLauncher.Models;
+using MihoyoBBS;
 
 namespace FufuLauncher.Services;
 
@@ -95,9 +96,21 @@ public class UnifiedCheckinService : IUnifiedCheckinService
                             continue;
                         }
 
-                        var genshin = new MihoyoBBS.Genshin();
-                        await genshin.InitializeAsync(config);
-                        var signResult = await genshin.SignAccountAsync(config, null, disabledUids);
+                        bool isOs = account.ConfigPath.Contains("lab");
+                        string signResult;
+
+                        if (isOs)
+                        {
+                            var os = new HoyolabCheckinService();
+                            await os.InitializeAsync(config.Account.Cookie);
+                            signResult = await os.SignAccountAsync(config.Account.Cookie, disabledUids);
+                        }
+                        else
+                        {
+                            var genshin = new Genshin();
+                            await genshin.InitializeAsync(config);
+                            signResult = await genshin.SignAccountAsync(config, null, disabledUids);
+                        }
 
                         bool success = !signResult.Contains("失败") && !signResult.Contains("异常");
                         if (success)
@@ -124,8 +137,9 @@ public class UnifiedCheckinService : IUnifiedCheckinService
                 }
 
                 result.GameResult.Success = result.GameResult.FailCount == 0;
-                int signDays = MihoyoBBS.GameCheckin.LastSignDays;
-                string rewardItem = MihoyoBBS.GameCheckin.LastRewardItem;
+                bool anyOs = activeAccounts.Any(a => a.ConfigPath.Contains("lab"));
+                int signDays = anyOs ? HoyolabCheckinService.LastSignDays : GameCheckin.LastSignDays;
+                string rewardItem = anyOs ? HoyolabCheckinService.LastRewardItem : GameCheckin.LastRewardItem;
                 result.GameSignDays = signDays.ToString();
                 result.GameRewardItem = rewardItem;
 
@@ -149,6 +163,17 @@ public class UnifiedCheckinService : IUnifiedCheckinService
             {
                 foreach (var account in activeAccounts)
                 {
+                    if (account.ConfigPath.Contains("lab"))
+                    {
+                        Report($"[{account.Nickname}] OS 账号跳过社区签到");
+                        result.AccountResults.Add(new AccountCheckinDetail
+                        {
+                            Nickname = account.Nickname,
+                            Items = { ("社区签到", null, "OS 账号不支持社区签到") }
+                        });
+                        continue;
+                    }
+
                     Report($"[{account.Nickname}] 正在社区签到...");
                     var communityResult = await _communityCheckinService.ExecuteCheckinAsync(
                         account, true, communityRead, communityLike, communityShare);
@@ -206,6 +231,12 @@ public class UnifiedCheckinService : IUnifiedCheckinService
                 {
                     foreach (var account in activeAccounts)
                     {
+                        if (account.ConfigPath.Contains("lab"))
+                        {
+                            result.CloudGameResult.SkippedCount++;
+                            continue;
+                        }
+
                         if (string.IsNullOrEmpty(account.CloudComboToken))
                         {
                             result.CloudGameResult.SkippedCount++;

--- a/FufuLauncher/Services/UnifiedCheckinService.cs
+++ b/FufuLauncher/Services/UnifiedCheckinService.cs
@@ -166,11 +166,15 @@ public class UnifiedCheckinService : IUnifiedCheckinService
                     if (account.ConfigPath.Contains("lab"))
                     {
                         Report($"[{account.Nickname}] OS 账号跳过社区签到");
-                        result.AccountResults.Add(new AccountCheckinDetail
-                        {
-                            Nickname = account.Nickname,
-                            Items = { ("社区签到", null, "OS 账号不支持社区签到") }
-                        });
+                        var acct = result.AccountResults.FirstOrDefault(a => a.Nickname == account.Nickname);
+                        if (acct != null)
+                            acct.Items.Add(("社区签到", null, "OS 账号跳过"));
+                        else
+                            result.AccountResults.Add(new AccountCheckinDetail
+                            {
+                                Nickname = account.Nickname,
+                                Items = { ("社区签到", null, "OS 账号跳过") }
+                            });
                         continue;
                     }
 
@@ -287,7 +291,7 @@ public class UnifiedCheckinService : IUnifiedCheckinService
             }
         }
 
-        int successAccounts = result.AccountResults.Count(a => a.Items.All(i => i.Success != false));
+        int successAccounts = result.AccountResults.Count(a => a.Items.Any(i => i.Success == true));
         int failAccounts = result.AccountResults.Count(a => a.Items.Any(i => i.Success == false));
 
         if (failAccounts == 0)

--- a/FufuLauncher/ViewModels/MainViewModel.cs
+++ b/FufuLauncher/ViewModels/MainViewModel.cs
@@ -905,17 +905,6 @@ private void BackgroundVideoPlayer_MediaFailed(MediaPlayer sender, MediaPlayerFa
             var isIntlRaw = await _localSettingsService.ReadSettingAsync("IsInternationalAccount");
             _isInternationalAccount = isIntlRaw != null && isIntlRaw.ToString().ToLower() == "true";
 
-            if (_isInternationalAccount)
-            {
-                Debug.WriteLine("[MainViewModel] 识别为国际服模式，跳过国服 API 请求");
-                await UpdateUI(() => {
-                    CheckinStatusText = "国际服模式";
-                    CheckinSummary = "Hoyoverse 账号已就绪";
-                    UpdateCheckinIconState("Ready");
-                });
-                return;
-            }
-            
             try 
             {
                 var targetUidObj = await _localSettingsService.ReadSettingAsync("CustomCheckinUid");
@@ -962,59 +951,21 @@ private async Task ExecuteCheckinAsync()
 
     try
     {
-        if (_isInternationalAccount)
+        var progress = new Progress<string>(msg =>
         {
-            string cookie = "";
-            try
+            _dispatcherQueue.TryEnqueue(() =>
             {
-                var path = Helpers.AppPaths.ConfigFile;
-                if (File.Exists(path))
-                {
-                    var json = await File.ReadAllTextAsync(path);
-                    var config = System.Text.Json.JsonSerializer.Deserialize<MihoyoBBS.Config>(json);
-                    cookie = config?.Account?.Cookie ?? "";
-                }
-            }
-            catch (Exception ex)
-            {
-                Debug.WriteLine($"读取 config.json 失败: {ex.Message}");
-            }
-
-            if (string.IsNullOrEmpty(cookie))
-            {
-                _notificationService.Show("签到失败", "未在 config.json 中找到有效 Cookie", NotificationType.Error, 3000);
-                CheckinStatusText = "缺少 Cookie";
-                return;
-            }
-
-            await UpdateUI(() =>
-            {
-                var win = new HoyolabCheckinWindow(cookie);
-                win.Activate();
+                CheckinButtonText = msg;
             });
+        });
 
-            CheckinStatusText = "国际服签到已发起";
-            CheckinSummary = "正在通过后台浏览器处理...";
-            _notificationService.Show("国际服签到", "正在启动静默浏览器执行签到", NotificationType.Success, 3000);
-        }
-        else
-        {
-            var progress = new Progress<string>(msg =>
-            {
-                _dispatcherQueue.TryEnqueue(() =>
-                {
-                    CheckinButtonText = msg;
-                });
-            });
+        var unifiedResult = await _unifiedCheckinService.ExecuteAllCheckinsAsync(progress);
 
-            var unifiedResult = await _unifiedCheckinService.ExecuteAllCheckinsAsync(progress);
+        CheckinStatusText = unifiedResult.OverallSuccess ? "签到完成" : "签到部分失败";
+        CheckinSummary = unifiedResult.SummaryMessage;
+        UpdateCheckinIconState(unifiedResult.OverallSuccess ? "已签到" : "Fail");
 
-            CheckinStatusText = unifiedResult.OverallSuccess ? "签到完成" : "签到部分失败";
-            CheckinSummary = unifiedResult.SummaryMessage;
-            UpdateCheckinIconState(unifiedResult.OverallSuccess ? "已签到" : "Fail");
-
-            _notificationService.Show("签到完成", unifiedResult.GetDetailedSummary(), unifiedResult.NotificationType, 5000);
-        }
+        _notificationService.Show("签到完成", unifiedResult.GetDetailedSummary(), unifiedResult.NotificationType, 5000);
     }
     catch (Exception ex)
     {


### PR DESCRIPTION
# 摘要

对 HoYoLAB 签到系统进行了重构，移除了 HoYoLAB 签到部分对于 WebView 的依赖，并新增对 HoYoLAB 账号信息的 API 支持

## 新增内容

新增``FufuLauncher/Models/HoyolabCheckinService.cs``，其中包含 HoYoLAB 账号信息 & API 支持

## 修改内容

### 修改签到按钮入口逻辑 

在``FufuLauncher/ViewModels/MainViewModel.cs``中移除了``_isInternationalAccount``分支

将签到按钮的逻辑统一为``UnifiedCheckinService.ExecuteAllCheckinsAsync()``

### 修改 HoYoLAB 签到状态获取逻辑

在 ``FufuLauncher/Services/HoyoverseCheckinService`` 中新增：

- ``config.lab.json`` 的搜索Fallback函数，解决 HoYoLAB 找不到``config.json``的报错
-  HoYoLAB Cookie 的识别（ltuid / ltoken / account_id）
- 签到状态的获取
  
### 国际服功能修改

在 UnifiedCheckinService 中：

- HoYoLAB 账号将会跳过云原神与社区签到

### Token 刷新逻辑优化

在 ``FufuLauncher/Services/TokenRefreshService`` 中：

- 将``stoken/mid``的检查提前，避免错误的 CN API 调用


# 测试情况

在本地使用HoYoLAB账号+米游社账号测试多账号，签到功能均为正常

---

Hoyolab功能好多都要完善

~~国际服这么没人权吗~~