### PR TITLE
fix:修复登录时因为httpClient未初始化导致的空引用错误

### DIFF
--- a/FufuLauncher/Views/Model/LoginQrWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/LoginQrWindow.xaml.cs
@@ -24,7 +24,7 @@ public sealed partial class LoginQrWindow : Window
     private const string SaltGame = "t0qEgfub6cvueAPgR5m9aQWWVciEer7v";
     private readonly string _deviceId;
     private readonly string _deviceFp;
-    private readonly HttpClient _httpClient;
+    private readonly HttpClient _httpClient = new HttpClient(new HttpClientHandler { UseCookies = false });
     
     private string _appTicket;
     private string _gameTicket;
@@ -55,9 +55,6 @@ public sealed partial class LoginQrWindow : Window
         _deviceFp = GenerateDeviceFingerprint();
         
         _gameDevice = Guid.NewGuid().ToString("N"); 
-    
-        var handler = new HttpClientHandler { UseCookies = false };
-        _httpClient = new HttpClient(handler);
     
         if (Content is FrameworkElement rootContent)
         {


### PR DESCRIPTION
将 _httpClient 声明改为带字段初始值设定项，修复点击登录时的空引用错误
<img width="1204" height="699" alt="image" src="https://github.com/user-attachments/assets/ad3b3a0d-2395-4fdc-a771-a7c3ad78dda9" />
