### PR TITLE
fix:统一文件选择器，修复[COMException]问题，优化祈愿分析截图导出

### DIFF
--- a/FufuLauncher/Services/IFilePickerService.cs
+++ b/FufuLauncher/Services/IFilePickerService.cs
@@ -1,8 +1,9 @@
-﻿/*
+/*
 Copyright (c) FufuLauncher Dev Team. All rights reserved.
 Licensed under the MIT License.
 */
 using System.Diagnostics;
+using Microsoft.UI.Xaml;
 
 namespace FufuLauncher.Services
 {
@@ -15,15 +16,42 @@ namespace FufuLauncher.Services
 
     public class FilePickerService : IFilePickerService
     {
+        public static IntPtr GetValidWindowHandle(Window window = null)
+        {
+            if (window != null)
+            {
+                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
+                if (hwnd != IntPtr.Zero) return hwnd;
+            }
+
+            var mainWindow = App.MainWindow;
+            if (mainWindow != null)
+            {
+                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(mainWindow);
+                if (hwnd != IntPtr.Zero) return hwnd;
+            }
+
+            return IntPtr.Zero;
+        }
+
+        public static bool InitializeWithValidWindow(object target, Window window = null)
+        {
+            var hwnd = GetValidWindowHandle(window);
+            if (hwnd == IntPtr.Zero)
+            {
+                Debug.WriteLine("[FilePickerService] 无法获取有效窗口句柄");
+                return false;
+            }
+            WinRT.Interop.InitializeWithWindow.Initialize(target, hwnd);
+            return true;
+        }
+
         public async Task<string> PickAudioFileAsync()
         {
             try
             {
-                var window = App.MainWindow;
-                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(window);
-
                 var picker = new Windows.Storage.Pickers.FileOpenPicker();
-                WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
+                if (!InitializeWithValidWindow(picker)) return null;
 
                 picker.ViewMode = Windows.Storage.Pickers.PickerViewMode.List;
                 picker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.MusicLibrary;
@@ -60,8 +88,7 @@ namespace FufuLauncher.Services
                     filePicker.FileTypeFilter.Add(type);
                 }
 
-                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
-                WinRT.Interop.InitializeWithWindow.Initialize(filePicker, hwnd);
+                if (!InitializeWithValidWindow(filePicker)) return null;
 
                 var file = await filePicker.PickSingleFileAsync();
                 return file?.Path;
@@ -82,8 +109,7 @@ namespace FufuLauncher.Services
                 };
                 folderPicker.FileTypeFilter.Add("*");
 
-                var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
-                WinRT.Interop.InitializeWithWindow.Initialize(folderPicker, hwnd);
+                if (!InitializeWithValidWindow(folderPicker)) return null;
 
                 var folder = await folderPicker.PickSingleFolderAsync();
                 return folder?.Path;

--- a/FufuLauncher/ViewModels/AgreementViewModel.cs
+++ b/FufuLauncher/ViewModels/AgreementViewModel.cs
@@ -8,6 +8,7 @@ using CommunityToolkit.Mvvm.Messaging;
 using FufuLauncher.Constants;
 using FufuLauncher.Contracts.Services;
 using FufuLauncher.Messages;
+using FufuLauncher.Services;
 using Microsoft.UI.Xaml;
 using System.Diagnostics;
 using Windows.Storage.Pickers;
@@ -164,8 +165,7 @@ namespace FufuLauncher.ViewModels
                 picker.SuggestedStartLocation = PickerLocationId.ComputerFolder;
                 picker.FileTypeFilter.Add("*");
 
-                var hwnd = WindowNative.GetWindowHandle(App.MainWindow);
-                InitializeWithWindow.Initialize(picker, hwnd);
+                if (!FilePickerService.InitializeWithValidWindow(picker)) return null;
 
                 var folder = await picker.PickSingleFolderAsync();
                 return folder?.Path;

--- a/FufuLauncher/ViewModels/BlankViewModel.cs
+++ b/FufuLauncher/ViewModels/BlankViewModel.cs
@@ -152,38 +152,21 @@ namespace FufuLauncher.ViewModels
             return;
         }
 
-        var mainWindow = App.MainWindow;
-        if (mainWindow == null)
-        {
-            await ShowError("无法获取主窗口句柄");
-            return;
-        }
-
-        var hwnd = WindowNative.GetWindowHandle(mainWindow);
-        if (hwnd == IntPtr.Zero)
-        {
-            await ShowError("窗口句柄无效，请以普通用户模式运行");
-            return;
-        }
-        
         var filePicker = new FileOpenPicker
         {
             SuggestedStartLocation = PickerLocationId.ComputerFolder,
             ViewMode = PickerViewMode.List
         };
-        
+
         filePicker.FileTypeFilter.Add(".exe");
 
-        try
+        if (!FilePickerService.InitializeWithValidWindow(filePicker))
         {
-            InitializeWithWindow.Initialize(filePicker, hwnd);
+            await ShowError("窗口句柄无效，请以普通用户模式运行");
+            return;
         }
-        catch (Exception ex)
-        {
-            Debug.WriteLine($"[警告] InitializeWithWindow失败: {ex.Message}");
-        }
-        
-        var file = await Task.Run(async () => await filePicker.PickSingleFileAsync());
+
+        var file = await filePicker.PickSingleFileAsync();
 
         if (file != null)
         {

--- a/FufuLauncher/ViewModels/GachaAnalysisModel.cs
+++ b/FufuLauncher/ViewModels/GachaAnalysisModel.cs
@@ -16,6 +16,7 @@ using FufuLauncher.Messages;
 using FufuLauncher.Models;
 using FufuLauncher.Services;
 using Microsoft.Data.Sqlite;
+using Microsoft.UI.Xaml;
 using MihoyoBBS;
 
 namespace FufuLauncher.ViewModels;
@@ -117,7 +118,7 @@ public partial class GachaAnalysisModel : ObservableObject
 
     public Action RequestMetadataScrapeAction;
     public Action<string> OnErrorAction;
-    public Func<IntPtr> GetWindowHandle;
+    public Func<Window> GetWindow;
     public Func<string, string, Task<bool>> OnUidMismatchAsync;
     public Func<string, string, string, Task> OnShowConfirmDialogAsync;
     public Func<string, Task> OnRequireReLoginAsync;
@@ -1590,10 +1591,8 @@ private async Task ExportUigfAsync(string version)
             Encoder = System.Text.Encodings.Web.JavaScriptEncoder.UnsafeRelaxedJsonEscaping
         });
 
-        var hwnd = GetWindowHandle?.Invoke() ?? IntPtr.Zero;
-        if (hwnd == IntPtr.Zero) hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
         var savePicker = new Windows.Storage.Pickers.FileSavePicker();
-        WinRT.Interop.InitializeWithWindow.Initialize(savePicker, hwnd);
+        if (!FilePickerService.InitializeWithValidWindow(savePicker, GetWindow?.Invoke())) return;
 
         savePicker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.DocumentsLibrary;
         savePicker.FileTypeChoices.Add("JSON 文件", new List<string> { ".json" });
@@ -1619,9 +1618,7 @@ private async Task ImportUigfAsync()
     try
     {
         var picker = new Windows.Storage.Pickers.FileOpenPicker();
-        var hwnd = GetWindowHandle?.Invoke() ?? IntPtr.Zero;
-        if (hwnd == IntPtr.Zero) hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
-        WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
+        if (!FilePickerService.InitializeWithValidWindow(picker, GetWindow?.Invoke())) return;
 
         picker.ViewMode = Windows.Storage.Pickers.PickerViewMode.List;
         picker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.DocumentsLibrary;

--- a/FufuLauncher/ViewModels/OtherViewModel.cs
+++ b/FufuLauncher/ViewModels/OtherViewModel.cs
@@ -319,21 +319,6 @@ namespace FufuLauncher.ViewModels
                     return;
                 }
 
-                var mainWindow = App.MainWindow;
-                if (mainWindow == null)
-                {
-                    await ShowErrorAsync("无法获取主窗口句柄");
-                    return;
-                }
-
-                var hwnd = WindowNative.GetWindowHandle(mainWindow);
-                if (hwnd == IntPtr.Zero)
-                {
-                    StatusMessage = "错误：窗口句柄无效";
-                    await ShowErrorAsync("窗口句柄无效，请以普通用户模式运行");
-                    return;
-                }
-
                 var picker = new FileOpenPicker
                 {
                     ViewMode = PickerViewMode.List,
@@ -341,13 +326,11 @@ namespace FufuLauncher.ViewModels
                     FileTypeFilter = { ".exe" }
                 };
 
-                try
+                if (!FilePickerService.InitializeWithValidWindow(picker))
                 {
-                    InitializeWithWindow.Initialize(picker, hwnd);
-                }
-                catch (Exception initEx)
-                {
-                    Debug.WriteLine($"[警告] InitializeWithWindow失败: {initEx.Message}");
+                    StatusMessage = "错误：窗口句柄无效";
+                    await ShowErrorAsync("窗口句柄无效，请以普通用户模式运行");
+                    return;
                 }
 
                 var file = await picker.PickSingleFileAsync();

--- a/FufuLauncher/ViewModels/PluginViewModel.cs
+++ b/FufuLauncher/ViewModels/PluginViewModel.cs
@@ -10,6 +10,7 @@ using System.Text;
 using System.Windows.Input;
 using CommunityToolkit.Mvvm.Input;
 using FufuLauncher.Models;
+using FufuLauncher.Services;
 using Windows.Storage.Pickers;
 
 namespace FufuLauncher.ViewModels;
@@ -253,8 +254,7 @@ public class PluginViewModel : INotifyPropertyChanged
         try
         {
             var picker = new FileOpenPicker();
-            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
-            WinRT.Interop.InitializeWithWindow.Initialize(picker, hwnd);
+            if (!FilePickerService.InitializeWithValidWindow(picker)) return;
 
             picker.ViewMode = PickerViewMode.List;
             picker.SuggestedStartLocation = PickerLocationId.ComputerFolder;

--- a/FufuLauncher/ViewModels/SettingsViewModel.cs
+++ b/FufuLauncher/ViewModels/SettingsViewModel.cs
@@ -726,8 +726,7 @@ namespace FufuLauncher.ViewModels
         private async Task DownloadAndSaveFileAsync(string url, string typeName, string extension)
         {
             var savePicker = new Windows.Storage.Pickers.FileSavePicker();
-            var hwnd = WinRT.Interop.WindowNative.GetWindowHandle(App.MainWindow);
-            WinRT.Interop.InitializeWithWindow.Initialize(savePicker, hwnd);
+            if (!FilePickerService.InitializeWithValidWindow(savePicker)) return;
 
             savePicker.SuggestedStartLocation = Windows.Storage.Pickers.PickerLocationId.PicturesLibrary;
             if (extension == ".mp4")

--- a/FufuLauncher/Views/Main/BlankPage.xaml.cs
+++ b/FufuLauncher/Views/Main/BlankPage.xaml.cs
@@ -1012,17 +1012,15 @@ private async Task ShowAutoPathDialog(string foundPath)
 
         private async Task PickGameFolderAsync()
         {
-            var hwnd = WindowNative.GetWindowHandle(App.MainWindow);
-            
             var filePicker = new FileOpenPicker
             {
                 SuggestedStartLocation = PickerLocationId.ComputerFolder
             };
-            
+
             filePicker.FileTypeFilter.Add(".exe");
-    
-            InitializeWithWindow.Initialize(filePicker, hwnd);
-            
+
+            if (!FilePickerService.InitializeWithValidWindow(filePicker)) return;
+
             var file = await filePicker.PickSingleFileAsync();
             if (file != null)
             {

--- a/FufuLauncher/Views/Main/PluginSettingsPage.xaml.cs
+++ b/FufuLauncher/Views/Main/PluginSettingsPage.xaml.cs
@@ -7,6 +7,7 @@ using System.Security.Cryptography;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
 using FufuLauncher.ViewModels;
+using FufuLauncher.Services;
 using CommunityToolkit.Mvvm.Messaging;
 using FufuLauncher.Messages;
 using Windows.System;
@@ -31,9 +32,6 @@ public sealed partial class PluginSettingsPage : Page
     private bool _isInitializing = true;
     private FileSystemWatcher _mainPluginWatcher;
     private bool _hasShownMainPluginMissingWarning = false;
-
-    [DllImport("user32.dll")]
-    private static extern IntPtr GetActiveWindow();
 
     public PluginSettingsPage()
     {
@@ -894,7 +892,7 @@ private async Task PerformFpsPluginRepairAsync(bool showUI)
             }
 
             var picker = new Windows.Storage.Pickers.FileOpenPicker();
-            WinRT.Interop.InitializeWithWindow.Initialize(picker, GetActiveWindow());
+            if (!FilePickerService.InitializeWithValidWindow(picker)) return;
             picker.ViewMode = Windows.Storage.Pickers.PickerViewMode.Thumbnail;
             picker.FileTypeFilter.Add(".png");
             picker.FileTypeFilter.Add(".jpg");

--- a/FufuLauncher/Views/Model/GachaAnalysisWindow.xaml
+++ b/FufuLauncher/Views/Model/GachaAnalysisWindow.xaml
@@ -1335,7 +1335,7 @@
                                   Visibility="{Binding ViewModel.ShowAnalysisContent, Converter={StaticResource BoolToVisibilityConverter}}">
 
                         <StackPanel x:Name="AnalysisExportTarget" Spacing="12" HorizontalAlignment="Stretch"
-                                    Background="{ThemeResource ApplicationPageBackgroundThemeBrush}" Padding="16">
+                                    Padding="16">
                             <Grid>
                                 <StackPanel>
                                     <TextBlock Text="祈愿分析" FontSize="22" FontWeight="SemiBold" />

--- a/FufuLauncher/Views/Model/GachaAnalysisWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/GachaAnalysisWindow.xaml.cs
@@ -333,7 +333,7 @@ namespace FufuLauncher.Views
             WindowManagerHelper.CenterWindowOnScreen(AppWindow, 1120, 720);
             LoadingRing.IsActive = true;
 
-            ViewModel.GetWindowHandle = () => WinRT.Interop.WindowNative.GetWindowHandle(this);
+            ViewModel.GetWindow = () => this;
             ViewModel.RequestMetadataScrapeAction = async () => await ViewModel.FetchMetadataFromApiAsync();
             this.Activated += OnWindowFirstActivated;
             ViewModel.OnUidMismatchAsync = async (currentUid, incomingUid) =>
@@ -696,6 +696,21 @@ namespace FufuLauncher.Views
             await renderTargetBitmap.RenderAsync(element);
 
             var pixels = await renderTargetBitmap.GetPixelsAsync();
+            var pixelArray = pixels.ToArray();
+
+            // 将透明像素替换为白色底色，避免在微信/QQ等不支持alpha的场景中显示黑底
+            for (var i = 0; i < pixelArray.Length; i += 4)
+            {
+                var alpha = pixelArray[i + 3];
+                if (alpha == 0)
+                {
+                    pixelArray[i] = 255;     // B
+                    pixelArray[i + 1] = 255;  // G
+                    pixelArray[i + 2] = 255;  // R
+                    pixelArray[i + 3] = 255;  // A
+                }
+            }
+
             var stream = new InMemoryRandomAccessStream();
             var encoder = await BitmapEncoder.CreateAsync(BitmapEncoder.PngEncoderId, stream);
 
@@ -706,7 +721,7 @@ namespace FufuLauncher.Views
                 (uint)renderTargetBitmap.PixelHeight,
                 96,
                 96,
-                pixels.ToArray());
+                pixelArray);
 
             await encoder.FlushAsync();
             return stream;


### PR DESCRIPTION
根据 PR #243 的 review 意见重新提交：

1. `InitializeWithValidWindow` 改为返回 `bool`，hwnd 为 Zero 时返回 false 并输出 Debug 日志，调用方可据此决定是否继续（保留用户错误提示路径）
2. `AnalysisExportTarget` 的 Background 从 UI 上移除，改为在 `RenderElementToStreamAsync` 导出逻辑中将透明像素替换为白色底色，避免微信/QQ 等场景显示黑底
3. 移除 `PluginSettingsPage` 中危险的 `GetActiveWindow()` P/Invoke
4. 修复 `BlankViewModel` 中 `Task.Run` 包裹 picker 导致的线程问题