### PR TITLE
feat: 添加界面字体大小滑块设置(0.8x~1.6x)

### DIFF
--- a/FufuLauncher/App.xaml.cs
+++ b/FufuLauncher/App.xaml.cs
@@ -399,6 +399,11 @@ public partial class App : Application
             var accountManager = GetService<AccountManager>();
             await accountManager.InitializeAsync();
             MainWindow = new MainWindow();
+            var fontScaleJson = await GetService<ILocalSettingsService>().ReadSettingAsync("FontScale");
+            if (fontScaleJson != null && double.TryParse(fontScaleJson.ToString(), out var savedFontScale))
+            {
+                FontScaleService.Apply(savedFontScale);
+            }
             _cpuUsageMonitor = new ProcessCpuUsageMonitor(_mainDispatcherQueue, GetService<ILocalSettingsService>());
             _cpuUsageMonitor.Start();
             if (MainWindow is MainWindow mainWindow)

--- a/FufuLauncher/MainWindow.xaml.cs
+++ b/FufuLauncher/MainWindow.xaml.cs
@@ -160,6 +160,10 @@ public sealed partial class MainWindow : WindowEx
             throw; 
         }
         
+        FontScaleService.HookWindow(this);
+        FontScaleService.HookFrame(ContentFrame);
+        FontScaleService.HookFrame(AgreementFrame);
+
         PluginFolderHelper.CheckAndCreatePluginsFolder();
 
         ShowWindowCommand = new RelayCommand(ShowWindow);

--- a/FufuLauncher/Services/FontScaleService.cs
+++ b/FufuLauncher/Services/FontScaleService.cs
@@ -1,0 +1,306 @@
+﻿/*
+Copyright (c) FufuLauncher Dev Team. All rights reserved.
+Licensed under the MIT License.
+*/
+using System.Runtime.CompilerServices;
+using Microsoft.UI.Xaml;
+using Microsoft.UI.Xaml.Controls;
+using Microsoft.UI.Xaml.Media;
+
+namespace FufuLauncher.Services;
+
+/// <summary>
+/// 全局字体缩放服务：在 0.8x ~ 1.6x 之间按比例缩放所有带 FontSize 的控件。
+/// WinUI 3 不支持 DynamicResource，因此通过遍历视觉树、为每个元素写入
+/// FontSize = 原值 * 缩放比例 的局部值来实现；并通过窗口/导航/容器挂接点
+/// 让之后新建的页面、窗口和虚拟化列表项也能自动套用当前缩放。
+/// </summary>
+public static class FontScaleService
+{
+    public const double MinScale = 0.8;
+    public const double MaxScale = 1.6;
+    public const double DefaultScale = 1.0;
+
+    /// <summary>原始字号达到该值时不再放大（原本就大的字体保持原样）。</summary>
+    public const double MaxScaleFontSize = 24;
+
+    /// <summary>缩放后的字号上限（防止放大后超出布局导致显示不全）。</summary>
+    public const double MaxScaledFontSize = 22;
+
+    private sealed class SizeHolder
+    {
+        public double Value;
+    }
+
+    /// <summary>当前缩放比例。</summary>
+    public static double CurrentScale { get; private set; } = DefaultScale;
+
+    private static readonly ConditionalWeakTable<DependencyObject, SizeHolder> _originalSizes = new();
+    private static readonly ConditionalWeakTable<DependencyObject, object> _hookedElements = new();
+    private static readonly ConditionalWeakTable<DependencyObject, object> _hookedContainers = new();
+    private static readonly List<FrameworkElement> _roots = new();
+
+    /// <summary>供代码中创建控件时使用：baseSize * 当前缩放。</summary>
+    public static double Scaled(double baseSize) => baseSize * CurrentScale;
+
+    /// <summary>应用新的缩放比例（自动限制在 0.8 ~ 1.6）。</summary>
+    public static void Apply(double scale)
+    {
+        double clamped = Math.Clamp(scale, MinScale, MaxScale);
+        CurrentScale = clamped;
+        foreach (FrameworkElement root in _roots.ToArray())
+        {
+            ApplyTo(root);
+        }
+    }
+
+    /// <summary>挂接一个窗口：将其内容注册为根并立即应用缩放。</summary>
+    public static void HookWindow(Window window)
+    {
+        if (window?.Content is FrameworkElement content)
+        {
+            HookRoot(content);
+            window.Closed += (_, _) => _roots.Remove(content);
+        }
+    }
+
+    /// <summary>挂接一个根元素（窗口内容 / ContentDialog 内容）。</summary>
+    public static void HookRoot(FrameworkElement? root)
+    {
+        if (root == null)
+        {
+            return;
+        }
+        if (!_roots.Contains(root))
+        {
+            _roots.Add(root);
+        }
+        ApplyTo(root);
+        root.Loaded -= OnRootLoaded;
+        root.Loaded += OnRootLoaded;
+        root.Unloaded -= OnRootUnloaded;
+        root.Unloaded += OnRootUnloaded;
+    }
+
+    /// <summary>挂接导航 Frame：每次导航后对新页面应用缩放。</summary>
+    public static void HookFrame(Frame? frame)
+    {
+        if (frame == null)
+        {
+            return;
+        }
+        frame.Navigated -= OnFrameNavigated;
+        frame.Navigated += OnFrameNavigated;
+    }
+
+    /// <summary>对某个根元素立即应用当前缩放。</summary>
+    public static void ApplyTo(FrameworkElement root)
+    {
+        if (root == null)
+        {
+            return;
+        }
+        Walk(root);
+    }
+
+    private static void OnRootLoaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement fe)
+        {
+            if (!_roots.Contains(fe))
+            {
+                _roots.Add(fe);
+            }
+            ApplyTo(fe);
+        }
+    }
+
+    private static void OnRootUnloaded(object sender, RoutedEventArgs e)
+    {
+        if (sender is FrameworkElement fe)
+        {
+            _roots.Remove(fe);
+        }
+    }
+
+    private static void OnFrameNavigated(object sender, Microsoft.UI.Xaml.Navigation.NavigationEventArgs e)
+    {
+        if (sender is Frame frame && frame.Content is FrameworkElement page)
+        {
+            ApplyTo(page);
+            HookLoaded(page, walkSubtree: true);
+            _ = DelayWalkAsync(page);
+        }
+    }
+
+    private static async Task DelayWalkAsync(FrameworkElement page)
+    {
+        try
+        {
+            await Task.Delay(250);
+            page.DispatcherQueue?.TryEnqueue(() => ApplyTo(page));
+        }
+        catch
+        {
+        }
+    }
+
+    private static void Walk(DependencyObject parent)
+    {
+        int count = VisualTreeHelper.GetChildrenCount(parent);
+        for (int i = 0; i < count; i++)
+        {
+            DependencyObject child = VisualTreeHelper.GetChild(parent, i);
+            if (child is FrameworkElement fe)
+            {
+                // 注入设置页整体不参与字体缩放
+                if (fe is FufuLauncher.Views.PluginSettingsPage)
+                {
+                    continue;
+                }
+                ApplyFontSize(fe);
+                if (fe is ListViewBase listView)
+                {
+                    HookContainer(listView);
+                }
+                if (fe is ItemsRepeater repeater)
+                {
+                    HookContainer(repeater);
+                }
+                Walk(child);
+            }
+        }
+    }
+
+    private static void ApplyFontSize(FrameworkElement element)
+    {
+        double original;
+        if (element is TextBlock textBlock)
+        {
+            original = GetOriginal(textBlock, textBlock.FontSize);
+        }
+        else if (element is FontIcon fontIcon)
+        {
+            original = GetOriginal(fontIcon, fontIcon.FontSize);
+        }
+        else if (element is RichTextBlock richTextBlock)
+        {
+            original = GetOriginal(richTextBlock, richTextBlock.FontSize);
+        }
+        else if (element is ContentPresenter contentPresenter)
+        {
+            original = GetOriginal(contentPresenter, contentPresenter.FontSize);
+        }
+        else if (element is Control control)
+        {
+            original = GetOriginal(control, control.FontSize);
+        }
+        else
+        {
+            return;
+        }
+
+        if (double.IsNaN(original) || original >= MaxScaleFontSize)
+        {
+            return;
+        }
+
+        double scaled = Math.Round(original * CurrentScale, 2);
+        if (scaled > MaxScaledFontSize)
+        {
+            scaled = MaxScaledFontSize;
+        }
+        if (element is TextBlock tb)
+        {
+            tb.FontSize = scaled;
+        }
+        else if (element is FontIcon fi)
+        {
+            fi.FontSize = scaled;
+        }
+        else if (element is RichTextBlock rtb)
+        {
+            rtb.FontSize = scaled;
+        }
+        else if (element is ContentPresenter cp)
+        {
+            cp.FontSize = scaled;
+        }
+        else if (element is Control c)
+        {
+            c.FontSize = scaled;
+        }
+
+        HookLoaded(element);
+    }
+
+    private static double GetOriginal(DependencyObject element, double current)
+    {
+        if (_originalSizes.TryGetValue(element, out SizeHolder holder))
+        {
+            return holder.Value;
+        }
+        _originalSizes.Add(element, new SizeHolder { Value = current });
+        return current;
+    }
+
+    private static void HookLoaded(FrameworkElement element, bool walkSubtree = false)
+    {
+        if (_hookedElements.TryGetValue(element, out _))
+        {
+            return;
+        }
+        _hookedElements.Add(element, new object());
+        element.Loaded += (_, _) =>
+        {
+            if (walkSubtree)
+            {
+                Walk(element);
+            }
+            else
+            {
+                ApplyFontSize(element);
+            }
+        };
+    }
+
+    private static void HookContainer(ListViewBase listView)
+    {
+        if (_hookedContainers.TryGetValue(listView, out _))
+        {
+            return;
+        }
+        _hookedContainers.Add(listView, new object());
+        listView.ContainerContentChanging += (_, args) =>
+        {
+            if (args.ItemContainer is FrameworkElement container)
+            {
+                HookLoaded(container, walkSubtree: true);
+                if (container.IsLoaded)
+                {
+                    Walk(container);
+                }
+            }
+        };
+    }
+
+    private static void HookContainer(ItemsRepeater repeater)
+    {
+        if (_hookedContainers.TryGetValue(repeater, out _))
+        {
+            return;
+        }
+        _hookedContainers.Add(repeater, new object());
+        repeater.ElementPrepared += (_, args) =>
+        {
+            if (args.Element is FrameworkElement element)
+            {
+                HookLoaded(element, walkSubtree: true);
+                if (element.IsLoaded)
+                {
+                    Walk(element);
+                }
+            }
+        };
+    }
+}

--- a/FufuLauncher/ViewModels/SettingsViewModel.cs
+++ b/FufuLauncher/ViewModels/SettingsViewModel.cs
@@ -119,6 +119,7 @@ namespace FufuLauncher.ViewModels
         [ObservableProperty] private bool _isAcrylicOverlayEnabled;
         [ObservableProperty] private bool _isPageOverlaySemiTransparentEnabled;
         [ObservableProperty] private double _pageOverlayTargetOpacity = 0.7;
+        [ObservableProperty] private double _fontScale = FontScaleService.DefaultScale;
         [ObservableProperty] private bool _isHamburgerButtonEnabled;
         
         [ObservableProperty] private bool _isHideGameNewsCardEnabled;
@@ -1021,6 +1022,19 @@ namespace FufuLauncher.ViewModels
             WeakReferenceMessenger.Default.Send(new PageOverlayTargetOpacityChangedMessage(clamped));
         }
 
+        partial void OnFontScaleChanged(double value)
+        {
+            if (_isInitializing) return;
+            var clamped = Math.Clamp(value, FontScaleService.MinScale, FontScaleService.MaxScale);
+            if (Math.Abs(clamped - value) > 0.0001)
+            {
+                FontScale = clamped;
+                return;
+            }
+            _ = _localSettingsService.SaveSettingAsync("FontScale", clamped);
+            FontScaleService.Apply(clamped);
+        }
+
         partial void OnIsHamburgerButtonEnabledChanged(bool value)
         {
             if (_isInitializing) return;
@@ -1270,6 +1284,12 @@ namespace FufuLauncher.ViewModels
                 PageOverlayTargetOpacity = Math.Clamp(pageOverlayOpacity, 0.1, 1.0);
             else
                 PageOverlayTargetOpacity = 0.7;
+
+            var fontScaleJson = await _localSettingsService.ReadSettingAsync("FontScale");
+            if (fontScaleJson != null && double.TryParse(fontScaleJson.ToString(), out var fontScale))
+                FontScale = Math.Clamp(fontScale, FontScaleService.MinScale, FontScaleService.MaxScale);
+            else
+                FontScale = FontScaleService.DefaultScale;
 
             var hamburgerButtonJson = await _localSettingsService.ReadSettingAsync("IsHamburgerButtonEnabled");
             IsHamburgerButtonEnabled = hamburgerButtonJson != null && Convert.ToBoolean(hamburgerButtonJson);

--- a/FufuLauncher/Views/AnnouncementWindow.xaml.cs
+++ b/FufuLauncher/Views/AnnouncementWindow.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class AnnouncementWindowL : Window
     public AnnouncementWindowL(string url)
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
         Title = "公告";
 

--- a/FufuLauncher/Views/Main/SettingsPage.xaml
+++ b/FufuLauncher/Views/Main/SettingsPage.xaml
@@ -512,6 +512,29 @@
                                     </StackPanel>
                                 </Grid>
 
+                                <Rectangle Style="{StaticResource RowDividerStyle}" />
+
+                                <Grid Style="{StaticResource SettingsRowStyle}">
+                                    <Grid.ColumnDefinitions>
+                                        <ColumnDefinition Width="Auto" />
+                                        <ColumnDefinition Width="*" />
+                                        <ColumnDefinition Width="Auto" />
+                                    </Grid.ColumnDefinitions>
+                                    <FontIcon Style="{StaticResource RowIconStyle}" Glyph="&#xE8F2;" />
+                                    <StackPanel Grid.Column="1" Style="{StaticResource RowTextStyle}">
+                                        <TextBlock Style="{StaticResource RowTitleStyle}" Text="字体大小" />
+                                        <TextBlock Style="{StaticResource RowCaptionStyle}" Text="调整界面所有文字大小（0.8× ～ 1.6×，默认 1.0×）" />
+                                    </StackPanel>
+                                    <StackPanel Grid.Column="2" Style="{StaticResource RowSubRowStyle}" Margin="16,0,0,0">
+                                        <Slider x:Name="FontScaleSlider"
+                                                Width="220" Minimum="0.8" Maximum="1.6" StepFrequency="0.05"
+                                                Value="{x:Bind ViewModel.FontScale, Mode=TwoWay}" />
+                                        <TextBlock VerticalAlignment="Center"
+                                                   MinWidth="44"
+                                                   Text="{Binding Value, ElementName=FontScaleSlider, Converter={StaticResource StringFormatConverter}, ConverterParameter='{}{0:F2}×'}" />
+                                    </StackPanel>
+                                </Grid>
+
                             </StackPanel>
                         </Border>
                     </StackPanel>

--- a/FufuLauncher/Views/Model/AchievementUpdaterWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/AchievementUpdaterWindow.xaml.cs
@@ -25,6 +25,7 @@ namespace FufuLauncher.Views
         public AchievementUpdaterWindow()
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         }
 
         private async void OnStartClick(object sender, RoutedEventArgs e)

--- a/FufuLauncher/Views/Model/AchievementWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/AchievementWindow.xaml.cs
@@ -52,6 +52,7 @@ public sealed partial class AchievementWindow : Window
     public AchievementWindow()
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/AgreementWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/AgreementWindow.xaml.cs
@@ -14,6 +14,8 @@ public sealed partial class AgreementWindow : WindowEx
     public AgreementWindow()
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
+        FufuLauncher.Services.FontScaleService.HookFrame(ContentFrame);
 
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/AnnouncementWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/AnnouncementWindow.xaml.cs
@@ -18,6 +18,8 @@ namespace FufuLauncher.Views
         public AnnouncementWindow()
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
+        FufuLauncher.Services.FontScaleService.HookFrame(ContentFrame);
 
             InitializeAppWindow();
 

--- a/FufuLauncher/Views/Model/BBSWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/BBSWindow.xaml.cs
@@ -137,6 +137,7 @@ namespace FufuLauncher.Views
         private BBSWindow(bool autoInitialize)
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
             _fingerprintService = App.GetService<IDeviceFingerprintService>();
 

--- a/FufuLauncher/Views/Model/BackgroundInitWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/BackgroundInitWindow.xaml.cs
@@ -16,6 +16,7 @@ public sealed partial class BackgroundInitWindow : Window
     public BackgroundInitWindow()
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         
         SystemBackdrop = new MicaBackdrop();
         

--- a/FufuLauncher/Views/Model/BrowserWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/BrowserWindow.xaml.cs
@@ -22,6 +22,7 @@ namespace FufuLauncher.Views
         public BrowserWindow()
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
             _config = BrowserConfig.Load();
             InitializeWindow();
             InitializeWebView();

--- a/FufuLauncher/Views/Model/CheckinCalendarWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/CheckinCalendarWindow.xaml.cs
@@ -19,6 +19,7 @@ namespace FufuLauncher.Views
         public CheckinCalendarWindow()
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/CloudCredentialWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/CloudCredentialWindow.xaml.cs
@@ -24,6 +24,7 @@ public sealed partial class CloudCredentialWindow : Window
     {
         _uid = uid;
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/DailyNoteWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/DailyNoteWindow.xaml.cs
@@ -182,6 +182,7 @@ namespace FufuLauncher.Views
         public DailyNoteWindow()
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
             Activated += DailyNoteWindow_Activated;
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/DatabaseEditorWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/DatabaseEditorWindow.xaml.cs
@@ -40,6 +40,7 @@ namespace FufuLauncher.Views
         public DatabaseEditorWindow()
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
             _repository = App.GetService<LocalSettingsRepository>();
 

--- a/FufuLauncher/Views/Model/DiagnosticsWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/DiagnosticsWindow.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class DiagnosticsWindow : Window
     public DiagnosticsWindow()
     {
         this.InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
         ViewModel = new DiagnosticsViewModel();
 

--- a/FufuLauncher/Views/Model/DownloadWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/DownloadWindow.xaml.cs
@@ -27,6 +27,7 @@ namespace FufuLauncher.Views
         public DownloadWindow(string installPath)
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
             _installPath = installPath;
             PathBox.Text = _installPath;
 

--- a/FufuLauncher/Views/Model/FeedbackWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/FeedbackWindow.xaml.cs
@@ -13,6 +13,7 @@ public sealed partial class FeedbackWindow : Window
     public FeedbackWindow()
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/GachaAnalysisWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/GachaAnalysisWindow.xaml.cs
@@ -328,6 +328,7 @@ namespace FufuLauncher.Views
             ViewModel = App.GetService<GachaAnalysisModel>();
             
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
             
             RootGrid.DataContext = this;
             ExtendsContentIntoTitleBar = true;

--- a/FufuLauncher/Views/Model/GachaDialog.xaml.cs
+++ b/FufuLauncher/Views/Model/GachaDialog.xaml.cs
@@ -19,6 +19,7 @@ public sealed partial class GachaDialog : ContentDialog
     {
         ViewModel = App.GetService<GachaViewModel>();
         this.InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookRoot(this.Content as Microsoft.UI.Xaml.FrameworkElement);
     }
 
     private async void GachaDialog_Loaded(object sender, RoutedEventArgs e)

--- a/FufuLauncher/Views/Model/GenshinDataWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/GenshinDataWindow.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class GenshinDataWindow : WindowEx
     public GenshinDataWindow()
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         ViewModel = App.GetService<GenshinViewModel>();
 
         RootGrid.DataContext = ViewModel;

--- a/FufuLauncher/Views/Model/GenshinHDRLuminanceSettingDialog.xaml.cs
+++ b/FufuLauncher/Views/Model/GenshinHDRLuminanceSettingDialog.xaml.cs
@@ -22,6 +22,7 @@ public sealed partial class GenshinHDRLuminanceSettingDialog : ContentDialog
     public GenshinHDRLuminanceSettingDialog()
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookRoot(this.Content as Microsoft.UI.Xaml.FrameworkElement);
         Loaded += GenshinHDRLuminanceSettingDialog_Loaded;
         Unloaded += GenshinHDRLuminanceSettingDialog_Unloaded;
     }

--- a/FufuLauncher/Views/Model/HighCpuUsageWarningWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/HighCpuUsageWarningWindow.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class HighCpuUsageWarningWindow : Window
     public HighCpuUsageWarningWindow(double cpuUsage)
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/HoyolabCheckinWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/HoyolabCheckinWindow.xaml.cs
@@ -17,6 +17,7 @@ namespace FufuLauncher.Views
         public HoyolabCheckinWindow(string cookie)
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
             _rawCookie = cookie;
             
             IntPtr hWnd = WinRT.Interop.WindowNative.GetWindowHandle(this);

--- a/FufuLauncher/Views/Model/InventoryWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/InventoryWindow.xaml.cs
@@ -26,6 +26,7 @@ namespace FufuLauncher.Views
         public InventoryWindow()
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/LoginQrWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/LoginQrWindow.xaml.cs
@@ -93,6 +93,7 @@ public sealed partial class LoginQrWindow : Window
         _httpClient = new HttpClient(handler);
 
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         _dispatcherQueue = DispatcherQueue.GetForCurrentThread();
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/PlayerInfoWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/PlayerInfoWindow.xaml.cs
@@ -70,6 +70,7 @@ namespace FufuLauncher.Views
         public PlayerInfoWindow()
         {
             InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
             
             ExtendsContentIntoTitleBar = true;
             SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/PluginMirrorDownloadWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/PluginMirrorDownloadWindow.xaml.cs
@@ -47,6 +47,7 @@ public sealed partial class PluginMirrorDownloadWindow : Window
         CancellationToken cancellationToken)
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
         _storeService = storeService;
         _mirrorProvider = mirrorProvider;

--- a/FufuLauncher/Views/Model/PresetManagerWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/PresetManagerWindow.xaml.cs
@@ -52,6 +52,7 @@ public sealed partial class PresetManagerWindow : Window
     public PresetManagerWindow()
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         _localSettingsService = App.GetService<ILocalSettingsService>();
         Title = "预设管理";
         

--- a/FufuLauncher/Views/Model/ScreenshotGalleryWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/ScreenshotGalleryWindow.xaml.cs
@@ -35,6 +35,7 @@ public sealed partial class ScreenshotGalleryWindow : Window
     public ScreenshotGalleryWindow(string gameScreenshotDirectory, string customScreenshotDirectory)
     {
         this.InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         _gameScreenshotDirectory = gameScreenshotDirectory;
         _customScreenshotDirectory = customScreenshotDirectory;
 

--- a/FufuLauncher/Views/Model/SecurityWebWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/SecurityWebWindow.xaml.cs
@@ -18,6 +18,7 @@ public sealed partial class SecurityWebWindow : Window
         _cookieString = cookieString;
         _targetUrl = targetUrl;
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
     
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);

--- a/FufuLauncher/Views/Model/SponsorWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/SponsorWindow.xaml.cs
@@ -15,6 +15,7 @@ public sealed partial class SponsorWindow : Window
     public SponsorWindow()
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         ExtendsContentIntoTitleBar = true;
     }
 

--- a/FufuLauncher/Views/Model/StarPromptWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/StarPromptWindow.xaml.cs
@@ -16,6 +16,7 @@ public sealed partial class StarPromptWindow : WindowEx
     public StarPromptWindow(ILocalSettingsService settingsService)
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
         _settingsService = settingsService;
         
         ExtendsContentIntoTitleBar = true;

--- a/FufuLauncher/Views/Model/UpdateNotificationWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/UpdateNotificationWindow.xaml.cs
@@ -21,6 +21,7 @@ public sealed partial class UpdateNotificationWindow : WindowEx
     public UpdateNotificationWindow(string updateInfoUrl, bool isPreview = false)
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
         _isPreview = isPreview;
 

--- a/FufuLauncher/Views/Model/VideoResourcesWindow.xaml.cs
+++ b/FufuLauncher/Views/Model/VideoResourcesWindow.xaml.cs
@@ -59,6 +59,7 @@ public sealed partial class VideoResourcesWindow : Window, INotifyPropertyChange
     public VideoResourcesWindow()
     {
         InitializeComponent();
+        FufuLauncher.Services.FontScaleService.HookWindow(this);
 
         ExtendsContentIntoTitleBar = true;
         SetTitleBar(AppTitleBar);


### PR DESCRIPTION
## 功能说明

在 **设置 → 外观** 新增"字体大小"滑块,可全局调整界面字号:

- 范围 **0.8x ~ 1.6x**(相对原始字号),步进 0.05,默认 **1.0x**(原始大小)
- 实时生效,选择保存到本地设置 `FontScale`,重启后记忆

## 实现方式

- 新增 `FufuLauncher/Services/FontScaleService.cs`:WinUI 3 不支持 DynamicResource,因此通过**遍历视觉树**,为每个控件写入 `FontSize = 原值 × 缩放比例` 的局部值
- 覆盖范围:主窗口、导航页面、全部子窗口/ContentDialog、`ListView`/`GridView`/`ItemsRepeater` 虚拟化列表项(通过 `ContainerContentChanging`/`ElementPrepared` + `IsLoaded` 处理异步生成的条目)
- 滑块变更时通过 `FontScaleService.Apply()` 重新遍历所有已打开窗口,即时更新

## 防溢出处理

- 原始字号 **>= 24** 的字体(标题、大数字、大图标)不参与缩放,避免过大
- 缩放后的字号**上限 22**,防止放大后超出固定布局导致文字显示不全

## 涉及改动

- 新增:`Services/FontScaleService.cs`
- `App.xaml.cs`(启动时应用已保存缩放)
- `MainWindow.xaml.cs`(挂接主窗口与导航 Frame)
- `ViewModels/SettingsViewModel.cs`(`FontScale` 属性 + 保存/加载)
- `Views/Main/SettingsPage.xaml`(外观页滑块 UI)
- 全部 `Window`/`ContentDialog` 构造函数(挂接缩放,约 35 个文件)

## 测试方法

1. 启动程序,默认应为原始字号
2. 设置 → 外观 → 拖动"字体大小"滑块,界面文字实时变化
3. 重启程序,缩放值被记住
4. 打开注入设置等页面,列表项字号跟随变化
