### PR TITLE
chore: 添加.gitattributes统一换行符

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,7 @@
+# Normalize line endings to LF in the repository.
+# Diff then ignores CRLF vs LF differences.
+* text=auto
+
+# Working tree stays CRLF to match .editorconfig
+*.cs text eol=crlf
+*.vb text eol=crlf


### PR DESCRIPTION
不同操作系统使用不同的换行符，统一换行符确保跨平台协作时代码的一致性，防止因操作系统换行符差异导致的代码混乱。