### PR TITLE
fix(LauncherService): 区分Launcher.dll缺失与加载失败的错误提示

### DIFF
--- a/FufuLauncher/Services/LauncherService.cs
+++ b/FufuLauncher/Services/LauncherService.cs
@@ -20,11 +20,20 @@ namespace FufuLauncher.Services
                          bool resin106, bool resin201, bool resin107009, bool resin107012, bool resin220007);
     }
 
+    public enum LauncherDllLoadError
+    {
+        None,
+        FileNotFound,
+        LoadFailed,
+        Exception
+    }
+
     public class LauncherService : ILauncherService
     {
         private const string DllName = "Launcher.dll";
         
         public static bool IsLauncherDllLoaded { get; private set; } = false;
+        public static LauncherDllLoadError DllLoadError { get; private set; } = LauncherDllLoadError.None;
 
         [DllImport("kernel32.dll", CharSet = CharSet.Unicode, SetLastError = true)]
         private static extern IntPtr LoadLibrary(string lpFileName);
@@ -46,6 +55,7 @@ namespace FufuLauncher.Services
                 {
                     Debug.WriteLine($"找不到核心文件: {absoluteDllPath}");
                     IsLauncherDllLoaded = false;
+                    DllLoadError = LauncherDllLoadError.FileNotFound;
                     return;
                 }
 
@@ -55,15 +65,18 @@ namespace FufuLauncher.Services
                     int errorCode = Marshal.GetLastWin32Error();
                     Debug.WriteLine($"加载 {DllName} 失败。文件存在，但缺少依赖项或架构不匹配。Win32错误码: {errorCode}");
                     IsLauncherDllLoaded = false;
+                    DllLoadError = LauncherDllLoadError.LoadFailed;
                     return;
                 }
                 
                 IsLauncherDllLoaded = true;
+                DllLoadError = LauncherDllLoadError.None;
             }
             catch (Exception ex)
             {
                 Debug.WriteLine($"初始化 LauncherService 时发生异常: {ex.Message}");
                 IsLauncherDllLoaded = false;
+                DllLoadError = LauncherDllLoadError.Exception;
             }
         }
 
@@ -120,7 +133,9 @@ namespace FufuLauncher.Services
         {
             if (!IsLauncherDllLoaded)
             {
-                errorMessage = "Launcher_DllNotLoaded".GetLocalized();
+                errorMessage = DllLoadError == LauncherDllLoadError.FileNotFound
+                    ? "Launcher_DllNotFound".GetLocalized()
+                    : "Launcher_DllNotLoaded".GetLocalized();
                 processId = 0;
                 return -1;
             }

--- a/FufuLauncher/Strings/en-US/Resources.resw
+++ b/FufuLauncher/Strings/en-US/Resources.resw
@@ -4256,6 +4256,9 @@ Files searched:
   <data name="Geetest_CaptchaTitle" xml:space="preserve">
     <value>CAPTCHA Verification</value>
   </data>
+  <data name="Launcher_DllNotFound" xml:space="preserve">
+    <value>Launcher.dll is missing. Injection is unavailable. Please ensure the file is built from FufuLauncher.UnlockerIsland.</value>
+  </data>
   <data name="Launcher_DllNotLoaded" xml:space="preserve">
     <value>Launcher.dll failed to load due to missing C++ runtime or antivirus blocking. Cannot start.</value>
   </data>

--- a/FufuLauncher/Strings/zh-CN/Resources.resw
+++ b/FufuLauncher/Strings/zh-CN/Resources.resw
@@ -4367,6 +4367,9 @@ UIGF v4.x/3.0/2.x</value>
   <data name="Geetest_CaptchaTitle" xml:space="preserve">
     <value>人机验证</value>
   </data>
+  <data name="Launcher_DllNotFound" xml:space="preserve">
+    <value>Launcher.dll 文件缺失，注入功能不可用。请确保编译时已从 FufuLauncher.UnlockerIsland 生成该文件。</value>
+  </data>
   <data name="Launcher_DllNotLoaded" xml:space="preserve">
     <value>由于系统缺少 C++ 运行库或核心文件被杀毒软件拦截，Launcher.dll 未加载成功，无法启动。</value>
   </data>


### PR DESCRIPTION
https://github.com/FufuLauncher/FufuLauncher/commit/a4de253916f1be30ecaca564cbbfdc7d7402528f 删除exe文件后直接clone仓库到本地编译会缺失Launcher.dll，此时的报错“由于系统缺少 C++ 运行库...”具有误导性。添加一个LauncherDllLoadError的enum区分错误类型。