### PR TITLE
修复注入启动参数解析问题

### DIFF
--- a/FufuLauncher/Program.cs
+++ b/FufuLauncher/Program.cs
@@ -105,20 +105,43 @@ private static void RunElevatedInjection(string[] args)
         }
 
         var gameExePath = args[1];
-        
-        int presetIndex = Array.IndexOf(args, "--preset");
-        if (presetIndex != -1 && args.Length > presetIndex + 1)
+        var launcher = new LauncherService();
+
+        string dllPath;
+        string commandLineArgs;
+        var separatorIndex = Array.IndexOf(args, "--", 2);
+        if (separatorIndex == -1 &&
+            TryParseLegacyElevatedInjection(args, out var legacyDllPath, out var legacyCommandLineArgs))
         {
-            string presetId = args[presetIndex + 1];
-            ApplyPreset(presetId);
+            dllPath = string.IsNullOrEmpty(legacyDllPath) ? launcher.GetDefaultDllPath() : legacyDllPath;
+            commandLineArgs = legacyCommandLineArgs;
+        }
+        else
+        {
+            if (separatorIndex == -1)
+            {
+                return;
+            }
+
+            dllPath = launcher.GetDefaultDllPath();
+
+            // Without an explicit preset, keep the config.ini prepared by the current in-app preset.
+            for (var i = 2; i < separatorIndex; i++)
+            {
+                if (string.Equals(args[i], "--preset", StringComparison.OrdinalIgnoreCase))
+                {
+                    if (i + 1 < separatorIndex)
+                    {
+                        ApplyPreset(args[++i]);
+                    }
+                }
+            }
+
+            commandLineArgs = string.Join(" ", args
+                .Skip(separatorIndex + 1)
+                .Select(argument => GameLauncherService.QuoteArgument(argument)));
         }
 
-        var tempLauncher = new LauncherService(); 
-        var dllPath = tempLauncher.GetDefaultDllPath();
-        
-        var commandLineArgs = args.Length > 4 ? args[4] : string.Empty; 
-
-        var launcher = new LauncherService();
         var result = launcher.LaunchGameAndInject(gameExePath, dllPath, commandLineArgs, out var errorMessage, out var pid);
 
         if (result != 0)
@@ -136,6 +159,24 @@ private static void RunElevatedInjection(string[] args)
     {
         Environment.Exit(exitCode);
     }
+}
+
+private static bool TryParseLegacyElevatedInjection(string[] args, out string dllPath, out string commandLineArgs)
+{
+    dllPath = string.Empty;
+    commandLineArgs = string.Empty;
+
+    if (args.Length != 5 ||
+        !int.TryParse(args[3], out _) ||
+        (!string.IsNullOrEmpty(args[2]) &&
+         !string.Equals(Path.GetExtension(args[2]), ".dll", StringComparison.OrdinalIgnoreCase)))
+    {
+        return false;
+    }
+
+    dllPath = args[2];
+    commandLineArgs = args[4];
+    return true;
 }
 
 private static void ApplyPreset(string presetId)

--- a/FufuLauncher/Services/GameLauncherService.cs
+++ b/FufuLauncher/Services/GameLauncherService.cs
@@ -802,7 +802,7 @@ namespace FufuLauncher.Services
                 var psi = new ProcessStartInfo
                 {
                     FileName = currentExe,
-                    Arguments = BuildElevatedArgumentString(gameExePath, dllPath, configMask, arguments),
+                    Arguments = BuildElevatedArgumentString(gameExePath, arguments),
                     UseShellExecute = true,
                     Verb = "runas",
                     WorkingDirectory = Path.GetDirectoryName(currentExe)
@@ -854,15 +854,17 @@ namespace FufuLauncher.Services
             }
         }
 
-        private static string BuildElevatedArgumentString(string gameExePath, string dllPath, int configMask, string commandLineArgs)
+        private static string BuildElevatedArgumentString(string gameExePath, string commandLineArgs)
         {
-            return $"--elevated-inject {QuoteArgument(gameExePath)} {QuoteArgument(dllPath)} {configMask} {QuoteArgument(commandLineArgs ?? string.Empty)}";
+            var arguments = $"--elevated-inject {QuoteArgument(gameExePath)} --";
+            return string.IsNullOrWhiteSpace(commandLineArgs) ? arguments : $"{arguments} {commandLineArgs}";
         }
 
-        private static string QuoteArgument(string argument)
+        internal static string QuoteArgument(string argument, bool forceQuotes = false)
         {
             if (string.IsNullOrEmpty(argument)) return "\"\"";
-            if (!argument.Contains(' ') && !argument.Contains('\t') && !argument.Contains('\n') && !argument.Contains('\v') && !argument.Contains('\"'))
+            if (!forceQuotes &&
+                !argument.Contains(' ') && !argument.Contains('\t') && !argument.Contains('\n') && !argument.Contains('\v') && !argument.Contains('\"'))
             {
                 return argument;
             }

--- a/FufuLauncher/Views/Main/BlankPage.Shortcut.cs
+++ b/FufuLauncher/Views/Main/BlankPage.Shortcut.cs
@@ -5,6 +5,7 @@ Licensed under the MIT License.
 using System.Text.Json;
 using FufuLauncher.Contracts.Services;
 using FufuLauncher.Helpers;
+using FufuLauncher.Services;
 using FufuLauncher.ViewModels;
 using Microsoft.UI.Xaml;
 using Microsoft.UI.Xaml.Controls;
@@ -57,13 +58,6 @@ public sealed partial class BlankPage
 
             var presetsDir = Path.Combine(AppContext.BaseDirectory, "Plugins", "Presets");
             var presets = new List<PresetModel>();
-            string activeId = null;
-
-            var stateFile = Path.Combine(presetsDir, "active_state.json");
-            if (File.Exists(stateFile))
-            {
-                try { activeId = JsonSerializer.Deserialize<Dictionary<string, string>>(File.ReadAllText(stateFile))?["ActiveId"]; } catch { }
-            }
 
             if (Directory.Exists(presetsDir))
             {
@@ -87,11 +81,6 @@ public sealed partial class BlankPage
                 Width = 300,
                 Margin = new Thickness(0, 10, 0, 0)
             };
-
-            if (activeId != null)
-            {
-                presetComboBox.SelectedItem = presets.FirstOrDefault(p => p.Id == activeId);
-            }
 
             var customParamsObj = await localSettings.ReadSettingAsync("CustomLaunchParameters");
             var customLaunchParams = customParamsObj as string;
@@ -124,7 +113,7 @@ public sealed partial class BlankPage
             string presetArg = "";
             if (presetComboBox.SelectedItem is PresetModel selectedPreset)
             {
-                presetArg = $" --preset \"{selectedPreset.Id}\"";
+                presetArg = $" --preset {GameLauncherService.QuoteArgument(selectedPreset.Id, forceQuotes: true)}";
             }
 
             string customParamsArg = "";
@@ -133,8 +122,8 @@ public sealed partial class BlankPage
                 customParamsArg = $" {customLaunchParams}";
             }
 
-            var argsOnly = $"--elevated-inject \"{finalExePath}\"{presetArg}{customParamsArg}";
-            var fullCommandLine = $"\"{appPath}\" {argsOnly}";
+            var argsOnly = $"--elevated-inject {GameLauncherService.QuoteArgument(finalExePath)}{presetArg} --{customParamsArg}";
+            var fullCommandLine = $"{GameLauncherService.QuoteArgument(appPath ?? string.Empty)} {argsOnly}";
 
             if (choiceResult == ContentDialogResult.Primary)
             {


### PR DESCRIPTION
## 问题

独立注入启动命令使用了新的 `--` 参数分隔格式，但 `RunElevatedInjection` 仍使用旧的固定参数位置解析，导致游戏启动参数无法完整传递。

例如：

`--elevated-inject "YuanShen.exe" -- -screen-width 2560 -screen-height 1600 -popupwindow`

无法正确转发全部参数。

## 修改

- 使用 `--` 区分启动器参数和游戏参数。
- 移除固定 `args[4]` 参数解析。
- 正确转发 `--` 后的所有游戏参数。
- 统一快捷方式生成和提权启动命令格式。
- 保留旧格式兼容。

## 测试

已使用 x64 Release 构建测试。

验证命令：

`FufuLauncher.exe --elevated-inject "YuanShen.exe" -- -screen-width 2560 -screen-height 1600 -popupwindow`

修复后游戏可以正确接收启动参数，并以 2560×1600 正常启动。